### PR TITLE
SDD-1: Wizard improvements — unified .sdd/specs/ layout, newline guard, gitignore prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The toolkit enforces the split by shipping four distinct slash commands, one per
 
 ## 📦 What's included
 
-- **Spec template** — Markdown template with YAML frontmatter (`.specs/template/spec.md`). Covers Context, Summary, Functional Requirements, Non-Goals, Edge Cases, Acceptance Criteria, Open Questions, Dependencies, Success Metrics, Testing Guidelines.
+- **Spec template** — Markdown template with YAML frontmatter (`.sdd/specs/template/spec.md`). Covers Context, Summary, Functional Requirements, Non-Goals, Edge Cases, Acceptance Criteria, Open Questions, Dependencies, Success Metrics, Testing Guidelines.
 - **Four slash commands** for Claude Code — `/spec-draft`, `/spec-plan`, `/spec-build`, `/spec-status`.
 - **`spec-source` skill** — reusable pull / adapt / push / conflict-detection across spec backends (`local`, `jira`, extensible to YouTrack / Linear / GitHub Issues).
 - **`spec-caveman` skill** — terse-response style that auto-activates inside SDD commands to cut token usage without losing technical substance. Commits and PRs are never compressed.
@@ -28,7 +28,7 @@ The toolkit enforces the split by shipping four distinct slash commands, one per
 
 ## 🧠 Goals
 
-- Make specs the **single source of truth**, whether they live in the repo (`.specs/<id>.md`) or an external system (Jira today, more adapters later). Either way, the local Markdown file is the canonical working copy.
+- Make specs the **single source of truth**, whether they live in the repo (`.sdd/specs/<id>.md`) or an external system (Jira today, more adapters later). Either way, the local Markdown file is the canonical working copy.
 - Enforce a **multi-step flow with human review** — draft, plan, build — so AI never jumps straight to code.
 - Support **non-linear iteration** — each phase can be re-entered as requirements shift, preserving history and marking obsolete steps instead of deleting them.
 - Stay **agent-neutral where it matters** — sources, config, and template live outside `.claude/` so other agents can plug in later.
@@ -76,11 +76,12 @@ The wizard:
 - copies `/spec-*` slash commands into `.claude/commands/`
 - copies the `spec-source` and `spec-caveman` skills into `.claude/skills/`
 - creates `.sdd/` with `sources.md` and `config.json`
-- copies the spec template into `.specs/template/spec.md`
-- creates `.specs/.cache/` and adds it to `.gitignore`
+- copies the spec template into `.sdd/specs/template/spec.md`
+- creates `.sdd/specs/.cache/` and adds it to `.gitignore`
 - asks whether to enable Jira; if yes, collects the project key and `acli` workspace
+- asks whether to gitignore the toolkit directories (`.sdd/`, `.claude/commands/`, `.claude/skills/`) — default no (commit by default)
 
-Re-run any time to reinitialize — existing files are overwritten. `.specs/<id>.md` files and `.specs/.cache/` contents are left untouched.
+Re-run any time to reinitialize — existing files are overwritten. `.sdd/specs/<id>.md` files and `.sdd/specs/.cache/` contents are left untouched.
 
 ---
 
@@ -105,7 +106,7 @@ All commands are invoked inside Claude Code:
 /spec-build PAR-224
 ```
 
-`/spec-draft` creates the feature branch, pulls the description from the source (Jira, or an empty template for `local`), and writes `.specs/PAR-224.md`. `/spec-plan` analyzes the codebase, asks you to resolve open questions, and appends an Implementation Plan. `/spec-build` walks the plan step by step, pausing after each so you can review before it commits.
+`/spec-draft` creates the feature branch, pulls the description from the source (Jira, or an empty template for `local`), and writes `.sdd/specs/PAR-224.md`. `/spec-plan` analyzes the codebase, asks you to resolve open questions, and appends an Implementation Plan. `/spec-build` walks the plan step by step, pausing after each so you can review before it commits.
 
 ### Non-linear iteration
 
@@ -130,10 +131,10 @@ Specs can come from multiple backends. Each backend implements a simple four-ope
 
 | Source | Requires | Notes |
 |---|---|---|
-| `local` | nothing | Default. The Markdown file under `.specs/` IS the source of truth. |
+| `local` | nothing | Default. The Markdown file under `.sdd/specs/` IS the source of truth. |
 | `jira` | Atlassian CLI (`acli`) + prior `acli auth login` | `/spec-draft` pulls the description, adapts it to the template (asking you to review), and caches it. `/spec-plan` and `/spec-build` push the updated body back at the end, after detecting any external drift and asking for confirmation. |
 
-Conflict detection uses a cache at `.specs/.cache/<spec_id>.<source>.md` (gitignored). If the remote has drifted since the last sync, you're shown a diff and asked to type `continue` before any overwrite.
+Conflict detection uses a cache at `.sdd/specs/.cache/<spec_id>.<source>.md` (gitignored). If the remote has drifted since the last sync, you're shown a diff and asked to type `continue` before any overwrite.
 
 ### Adding a new source
 
@@ -175,13 +176,13 @@ your-project/
 │   └── skills/
 │       ├── spec-source/
 │       └── spec-caveman/
-├── .sdd/
-│   ├── config.json             # Wizard-generated source config
-│   └── sources.md              # Adapter catalog
-└── .specs/
-    ├── template/spec.md        # Spec template
-    ├── .cache/                 # Last-known remote state (gitignored)
-    └── <SPEC-ID>.md            # One file per spec
+└── .sdd/
+    ├── config.json             # Wizard-generated source config
+    ├── sources.md              # Adapter catalog
+    └── specs/
+        ├── template/spec.md    # Spec template
+        ├── .cache/             # Last-known remote state (gitignored)
+        └── <SPEC-ID>.md        # One file per spec
 ```
 
 ---
@@ -190,7 +191,8 @@ your-project/
 
 - **Toolkit update** — `git pull` in your clone of this repo, then re-run `spec-init` in each target project. Existing commands, skills, template, and `sources.md` are overwritten; your specs and config are not.
 - **Reset a single project** — delete `.claude/commands/spec-*.md`, `.claude/skills/spec-*/`, `.sdd/`, then re-run `spec-init`.
-- **Move off the toolkit** — `.specs/` is just Markdown; it keeps working without the commands.
+- **Move off the toolkit** — `.sdd/specs/` is just Markdown; it keeps working without the commands.
+- **Legacy `.specs/` directory** — if you have spec files from an older install under `.specs/`, the wizard leaves them untouched. Move them to `.sdd/specs/` manually after reinitializing.
 
 ---
 

--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -16,7 +16,7 @@ User input: $ARGUMENTS
 
 ### 1. Load and validate
 
-Read `.specs/<spec_id>.md`. Parse frontmatter (`source`, `source_ref`). Body must contain an `## Implementation Plan` section with checkboxes. Missing → tell user to run `/spec-plan <spec_id>` first and stop.
+Read `.sdd/specs/<spec_id>.md`. Parse frontmatter (`source`, `source_ref`). Body must contain an `## Implementation Plan` section with checkboxes. Missing → tell user to run `/spec-plan <spec_id>` first and stop.
 
 ### 2. Find next step
 
@@ -61,7 +61,7 @@ Type any feedback to request changes before committing.
 1. `git add -A`
 2. Commit: `<spec_id>: step N - <short step description>`
 3. Update spec: change `- [ ] Step N:` to `- [x] Step N:` for the completed step.
-4. `git add .specs/<spec_id>.md && git commit --amend --no-edit`
+4. `git add .sdd/specs/<spec_id>.md && git commit --amend --no-edit`
 5. Print: `✓ Step N committed. Moving to next step...`
 
 ### 7. Loop
@@ -73,7 +73,7 @@ Back to step 2. Repeat until done.
 All checked or superseded:
 
 1. Sync to source. `source == "local"` → skip. Otherwise invoke `spec-source`:
-   - `push(source, source_ref, body_of(.specs/<spec_id>.md))`.
+   - `push(source, source_ref, body_of(.sdd/specs/<spec_id>.md))`.
    - Skill handles drift detection, user confirmation, frontmatter stripping, cache update.
    - Capture result: `pushed | aborted by user | skipped (conflict unresolved)`.
 

--- a/ai/claude/commands/spec-draft.md
+++ b/ai/claude/commands/spec-draft.md
@@ -31,7 +31,7 @@ If any field cannot be inferred, ask the user — do not guess.
 
 ### 2. Detect re-entry
 
-Check whether `.specs/<spec_id>.md` exists.
+Check whether `.sdd/specs/<spec_id>.md` exists.
 
 - **Exists** → refresh mode. Skip branch creation. Refresh body and commit as a standalone commit.
 - **Missing** → new draft mode. Do dirty tree check and create branch.
@@ -41,7 +41,7 @@ Check whether `.specs/<spec_id>.md` exists.
 Run `git status --porcelain`.
 
 - New draft: non-empty → abort, ask user to commit or stash.
-- Refresh: anything other than `.specs/<spec_id>.md` → abort.
+- Refresh: anything other than `.sdd/specs/<spec_id>.md` → abort.
 
 ### 4. Choose source
 
@@ -58,7 +58,7 @@ Invoke `spec-source`:
 
 1. `pull(source, source_ref)` → raw body.
 2. `adapt(source, body)` → proposed body (user must `continue` to accept).
-3. Skill writes `.specs/.cache/<source_ref>.<source>.md` on success.
+3. Skill writes `.sdd/specs/.cache/<source_ref>.<source>.md` on success.
 
 ### 6. Create branch (new draft only)
 
@@ -66,7 +66,7 @@ Skip in refresh mode. Switch to a new branch from HEAD using `branch_name`. If t
 
 ### 7. Write spec file
 
-Read `.specs/template/spec.md`. Create `.specs/<spec_id>.md` with:
+Read `.sdd/specs/template/spec.md`. Create `.sdd/specs/<spec_id>.md` with:
 
 - Frontmatter:
   ```yaml
@@ -91,7 +91,7 @@ No implementation details, code examples, or file paths — product-level docume
 Refresh mode, after writing:
 
 ```
-git add .specs/<spec_id>.md .specs/.cache/<spec_id>.<source>.md 2>/dev/null
+git add .sdd/specs/<spec_id>.md .sdd/specs/.cache/<spec_id>.<source>.md 2>/dev/null
 git commit -m "<spec_id>: refresh spec from <source>"
 ```
 
@@ -102,7 +102,7 @@ New draft: leave uncommitted — user commits after review.
 Print exactly:
 
 ```
-Spec:    .specs/<spec_id>.md
+Spec:    .sdd/specs/<spec_id>.md
 Branch:  <branch_name>
 Title:   <spec_title>
 Source:  <source>[:<source_ref>]

--- a/ai/claude/commands/spec-plan.md
+++ b/ai/claude/commands/spec-plan.md
@@ -21,7 +21,7 @@ User input: $ARGUMENTS
 
 ### 2. Load spec
 
-Read `.specs/<spec_id>.md`. Missing → tell user to run `/spec-draft <spec_id> ...` and stop.
+Read `.sdd/specs/<spec_id>.md`. Missing → tell user to run `/spec-draft <spec_id> ...` and stop.
 
 Parse YAML frontmatter. Remember `source`, `source_ref`.
 
@@ -116,7 +116,7 @@ Plan rules (both modes):
 
 Otherwise, invoke `spec-source`:
 
-1. `push(source, source_ref, body_of(.specs/<spec_id>.md))`.
+1. `push(source, source_ref, body_of(.sdd/specs/<spec_id>.md))`.
 2. Skill handles drift detection, user confirmation, frontmatter stripping, and cache update.
 3. Capture result: `pushed | aborted by user | skipped (conflict unresolved)`.
 

--- a/ai/claude/commands/spec-status.md
+++ b/ai/claude/commands/spec-status.md
@@ -19,13 +19,13 @@ User input: $ARGUMENTS
 
 ### 2. Locate specs
 
-- Single: read `.specs/<spec_id>.md`. Missing → print:
+- Single: read `.sdd/specs/<spec_id>.md`. Missing → print:
   ```
-  No spec found at .specs/<spec_id>.md
+  No spec found at .sdd/specs/<spec_id>.md
   Run: /spec-draft <spec_id> <type> <title>
   ```
   and stop.
-- List: glob `.specs/*.md`, exclude `.specs/template/` and `.specs/.cache/`.
+- List: glob `.sdd/specs/*.md`, exclude `.sdd/specs/template/` and `.sdd/specs/.cache/`.
 
 ### 3. Derive state per spec
 
@@ -47,7 +47,7 @@ Counts when plan exists:
 - `pending` — `- [ ]`.
 
 Source sync hints (no remote calls):
-- Non-local source + cache exists at `.specs/.cache/<spec_id>.<source>.md` → `last_sync = mtime`.
+- Non-local source + cache exists at `.sdd/specs/.cache/<spec_id>.<source>.md` → `last_sync = mtime`.
 - Non-local source + cache missing → `last_sync: never`.
 
 Branch hint: run `git branch --show-current` once. Per spec: compare frontmatter `branch` to current; mark `on_branch: yes|no`.

--- a/ai/claude/skills/spec-caveman/SKILL.md
+++ b/ai/claude/skills/spec-caveman/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Terse lite-level response style for SDD commands (/spec-draft, /spec-plan, /spec-build,
   /spec-status). Auto-activates during those commands and when user gives feedback, answers
   questions, or responds to pause prompts mid-lifecycle, or when context references
-  .specs/, .sdd/, the spec-source skill, Implementation Plan, or Acceptance Criteria.
+  .sdd/, the spec-source skill, Implementation Plan, or Acceptance Criteria.
   Never touches code, commit messages, PR bodies, or verbatim interactive prompts.
 ---
 
@@ -23,7 +23,7 @@ Keep: articles, full sentences, subject+verb grammar. Professional, tight.
 Pattern: `[thing] [action] [reason]. [next step].`
 
 - No: "Sure! I'd be happy to help. The issue is likely a stale cache."
-- Yes: "The issue is a stale cache. Clear `.specs/.cache/<id>.jira.md` and re-run `/spec-plan`."
+- Yes: "The issue is a stale cache. Clear `.sdd/specs/.cache/<id>.jira.md` and re-run `/spec-plan`."
 
 Technical terms exact. Code blocks unchanged. Errors quoted verbatim.
 

--- a/ai/claude/skills/spec-source/SKILL.md
+++ b/ai/claude/skills/spec-source/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-source
-description: Pull, adapt, push, and detect drift for specs stored in external systems (Jira, future YouTrack, etc.). Use whenever a spec command needs to sync `.specs/<id>.md` with its external source of truth.
+description: Pull, adapt, push, and detect drift for specs stored in external systems (Jira, future YouTrack, etc.). Use whenever a spec command needs to sync `.sdd/specs/<id>.md` with its external source of truth.
 ---
 
 # spec-source
@@ -25,7 +25,7 @@ Returns the external description as a markdown body (no frontmatter).
 
 ### `adapt(source, body) -> proposed_body`
 
-Transforms raw external content into the spec template layout from `.specs/template/spec.md`.
+Transforms raw external content into the spec template layout from `.sdd/specs/template/spec.md`.
 
 1. Body already matches template → return unchanged.
 2. Else:
@@ -48,14 +48,14 @@ Sends local body to the external source and refreshes the cache.
 4. Write stripped body to a temp file.
 5. Follow push procedure for `source` in `.sdd/sources.md` using the temp file.
 6. Auth failure → handle same as `pull`.
-7. Success → overwrite `.specs/.cache/<ref>.<source>.md` with pushed body. Create `.specs/.cache/` if missing.
+7. Success → overwrite `.sdd/specs/.cache/<ref>.<source>.md` with pushed body. Create `.sdd/specs/.cache/` if missing.
 
 ### `detect_conflict(source, ref) -> (has_conflict, diff)`
 
 Checks for external drift since the last known sync.
 
 1. `source == "local"` → return `(false, "")`.
-2. `.specs/.cache/<ref>.<source>.md` missing → pull remote, write cache, return `(false, "")`.
+2. `.sdd/specs/.cache/<ref>.<source>.md` missing → pull remote, write cache, return `(false, "")`.
 3. Pull current remote body.
 4. `diff -u` against cache.
 5. If different, print:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -247,7 +247,7 @@ cat > "$DST_CONFIG" <<EOF
 EOF
 echo "  wrote $DST_CONFIG"
 
-ensure_gitignore_line ".specs/.cache/"
+ensure_gitignore_line ".sdd/specs/.cache/"
 echo "  updated $DST_GITIGNORE"
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,8 +47,8 @@ DST_SKILLS="$DST_CLAUDE/skills"
 DST_SDD="$TARGET_DIR/.sdd"
 DST_SOURCES_DOC="$DST_SDD/sources.md"
 DST_CONFIG="$DST_SDD/config.json"
-DST_TEMPLATE_DIR="$TARGET_DIR/.specs/template"
-DST_CACHE_DIR="$TARGET_DIR/.specs/.cache"
+DST_TEMPLATE_DIR="$TARGET_DIR/.sdd/specs/template"
+DST_CACHE_DIR="$TARGET_DIR/.sdd/specs/.cache"
 DST_GITIGNORE="$TARGET_DIR/.gitignore"
 
 # ---------------------------------------------------------------------------
@@ -160,9 +160,9 @@ This will:
   • copy slash commands into .claude/commands/
   • copy skills into .claude/skills/
   • create .sdd/ with sources.md and config.json
-  • copy the spec template into .specs/template/
-  • create .specs/.cache/ for source sync state
-  • add .specs/.cache/ to .gitignore
+  • copy the spec template into .sdd/specs/template/
+  • create .sdd/specs/.cache/ for source sync state
+  • add .sdd/specs/.cache/ to .gitignore
 
 Existing files will be overwritten.
 ────────────────────────────────────────────────────
@@ -230,7 +230,7 @@ cat > "$DST_CONFIG" <<EOF
   "sources": {
     "local": {
       "enabled": true,
-      "path": ".specs"
+      "path": ".sdd/specs"
     },
     "jira": {
       "enabled": $JIRA_ENABLED,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -168,6 +168,7 @@ This will:
   • copy the spec template into .sdd/specs/template/
   • create .sdd/specs/.cache/ for source sync state
   • add .sdd/specs/.cache/ to .gitignore
+  • (optional) gitignore .sdd/, .claude/commands/, .claude/skills/
 
 Existing files will be overwritten.
 ────────────────────────────────────────────────────
@@ -201,6 +202,12 @@ if [ "$JIRA_ENABLED" = "true" ]; then
   JIRA_PROJECT_KEY=$(prompt "Default Jira project key (e.g. PAR)" "")
   JIRA_WORKSPACE=$(prompt "acli workspace" "")
 fi
+
+echo
+echo "Version control"
+echo "---------------"
+echo "The toolkit directories can be kept local-only (gitignored) or committed."
+GITIGNORE_TOOLKIT=$(prompt_yn "Exclude toolkit from version control (.sdd/, .claude/commands/, .claude/skills/)?" "n")
 
 # ---------------------------------------------------------------------------
 # Apply.
@@ -248,6 +255,12 @@ EOF
 echo "  wrote $DST_CONFIG"
 
 ensure_gitignore_line ".sdd/specs/.cache/"
+
+if [ "$GITIGNORE_TOOLKIT" = "true" ]; then
+  ensure_gitignore_line ".sdd/"
+  ensure_gitignore_line ".claude/commands/"
+  ensure_gitignore_line ".claude/skills/"
+fi
 echo "  updated $DST_GITIGNORE"
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -125,6 +125,11 @@ ensure_gitignore_line() {
     return
   fi
   if ! grep -Fxq "$line" "$DST_GITIGNORE"; then
+    # Guard: if file is non-empty and last byte is not \n, add one.
+    # tail -c 1 | wc -l returns 1 when last byte is \n, 0 for any other byte.
+    if [ -s "$DST_GITIGNORE" ] && [ "$(tail -c 1 "$DST_GITIGNORE" | wc -l)" -eq 0 ]; then
+      printf '\n' >> "$DST_GITIGNORE"
+    fi
     printf '%s\n' "$line" >> "$DST_GITIGNORE"
   fi
 }

--- a/sdd/sources.md
+++ b/sdd/sources.md
@@ -11,11 +11,11 @@ Every adapter defines four operations:
 | Operation | Input | Output | Used by |
 |---|---|---|---|
 | `pull(ref)` | external reference | markdown body (no frontmatter) | `/spec-draft` |
-| `adapt(body)` | raw external body | markdown matching `.specs/template/spec.md` | `/spec-draft` |
+| `adapt(body)` | raw external body | markdown matching `.sdd/specs/template/spec.md` | `/spec-draft` |
 | `push(ref, body)` | reference + body (frontmatter stripped) | success/failure | `/spec-plan`, `/spec-build` |
 | `detect_conflict(ref, cached_body)` | reference + last-known body | `(has_conflict, diff)` | `/spec-plan`, `/spec-build` |
 
-Cache: `.specs/.cache/<spec_id>.<source>.md`, written on every successful `pull` or `push`, gitignored.
+Cache: `.sdd/specs/.cache/<spec_id>.<source>.md`, written on every successful `pull` or `push`, gitignored.
 
 ## Frontmatter rule
 
@@ -40,7 +40,7 @@ and wait.
 
 - `pull(ref)`: `acli jira workitem view <ref> --json`, extract `description`. Empty → empty template body.
 - `adapt(body)`: match sections to template headers. If mismatched: map into closest sections, leave unmatched as `...`, append unmapped under `## Original Description`. Show proposal, require `continue` before writing.
-- `push(ref, body)`: strip frontmatter, write to temp file, run `acli jira workitem edit <ref> --description-file=<tmp>`, then overwrite `.specs/.cache/<ref>.jira.md` with the pushed body.
+- `push(ref, body)`: strip frontmatter, write to temp file, run `acli jira workitem edit <ref> --description-file=<tmp>`, then overwrite `.sdd/specs/.cache/<ref>.jira.md` with the pushed body.
 - `detect_conflict(ref, cached_body)`: pull current Jira body, diff against `cached_body`. If different, require `continue` before overwrite.
 
 ## Adding an adapter


### PR DESCRIPTION
## Summary

- **Unified toolkit directory**: absorbs `.specs/` into `.sdd/specs/`. After a fresh `spec-init`, only `.claude/` and `.sdd/` appear at the target root. Spec files at `.sdd/specs/<id>.md`, cache at `.sdd/specs/.cache/`, template at `.sdd/specs/template/spec.md`.
- **Trailing-newline guard**: `ensure_gitignore_line` in `setup.sh` now checks whether `.gitignore` ends with `\n` before appending; if not, it inserts one. Portable under bash 3.2/macOS via `tail -c 1 | wc -l`.
- **Gitignore prompt**: new wizard question (default no) offers to exclude `.sdd/`, `.claude/commands/`, and `.claude/skills/` from version control. Cache entry (`.sdd/specs/.cache/`) is always added unconditionally.

## Files changed

| File | Change |
|---|---|
| `sdd/sources.md` | Path refs → `.sdd/specs/...` |
| `ai/claude/skills/spec-source/SKILL.md` | All `.specs/` refs → `.sdd/specs/` |
| `ai/claude/skills/spec-caveman/SKILL.md` | Trigger context + example cache path |
| `ai/claude/commands/spec-draft.md` | 6 path refs |
| `ai/claude/commands/spec-plan.md` | 2 path refs |
| `ai/claude/commands/spec-build.md` | 3 path refs |
| `ai/claude/commands/spec-status.md` | 4 path refs |
| `scripts/setup.sh` | Destinations, config, banner, newline guard, cache entry, new prompt |
| `README.md` | Layout diagram, feature list, wizard description, migration note |
| `CLAUDE.md` | Mapping table, invariants (gitignored locally, not in PR) |

## Test plan

- [x] Fresh install: only `.claude/` and `.sdd/` at root, no `.specs/`
- [x] `.gitignore` without trailing newline gets exactly one newline prepended before append, no content corruption
- [x] Prompt yes-path appends `.sdd/`, `.claude/commands/`, `.claude/skills/` (plus unconditional cache entry)
- [x] Prompt no-path appends only `.sdd/specs/.cache/`
- [x] Re-run is non-destructive to existing `.sdd/specs/<id>.md` files
- [x] Pre-existing `.specs/` directory is left untouched
- [x] All installed commands and skills contain zero `.specs/` references; all paths resolve under `.sdd/specs/`

## Migration note for existing targets

Re-run `spec-init`. Then move any existing `.specs/<id>.md` files to `.sdd/specs/` manually — the wizard leaves the old directory untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)