### PR TITLE
SDD-2: Auto-Update Repository on Terminal Open

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,36 @@ your-project/
 
 ---
 
+## 🔔 Auto-Update Check
+
+The setup wizard offers to add an update check hook to your shell profile. When a new terminal session opens, the hook silently checks whether the upstream repository has a newer commit. If one is found, it prints a one-line notification and asks for confirmation before applying anything.
+
+The check:
+- runs at most once per 24 hours (cooldown stored in `~/.sdd/.last_update_check`)
+- times out after 5 seconds if the network is unavailable, and fails silently
+- only prompts when your local commit differs from the remote HEAD
+- applies the update with `git pull` in your toolkit clone — target projects are not touched
+
+### Manual installation
+
+If you declined the wizard prompt or want to add the hook yourself:
+
+**zsh** — add to `~/.zshrc`:
+
+```zsh
+[ -x "/path/to/ai-spec-dev-kit/scripts/check-update.sh" ] && "/path/to/ai-spec-dev-kit/scripts/check-update.sh"
+```
+
+**bash** — add to `~/.bash_profile`:
+
+```bash
+[ -x "/path/to/ai-spec-dev-kit/scripts/check-update.sh" ] && "/path/to/ai-spec-dev-kit/scripts/check-update.sh"
+```
+
+Replace `/path/to/ai-spec-dev-kit` with the absolute path to your clone. The wizard injects this line automatically with the correct path when you answer **y** to the prompt.
+
+---
+
 ## 🙏 Credits & attribution
 
 The `spec-caveman` skill is adapted from **Julius Brussee's `caveman`** project:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ cd ai-spec-dev-kit
 
 The script symlinks `scripts/setup.sh` into the first writable directory it finds on your PATH (`$HOME/.local/bin`, `/usr/local/bin`, or `/opt/homebrew/bin`). After this you can run `spec-init` from any project root.
 
-### 3. Initialize the toolkit in your target project
+### 3. (Optional) Enable auto-update checks on terminal open
+
+```bash
+./scripts/install-hook.sh
+```
+
+The script detects your shell (`$SHELL`), resolves the right profile (`~/.zshrc` for zsh, `~/.bash_profile` for bash), and appends a one-line hook. Safe to re-run — the line is injected only once. See [Auto-Update Check](#-auto-update-check) for details.
+
+### 4. Initialize the toolkit in your target project
 
 ```bash
 cd /path/to/your/project
@@ -161,7 +169,9 @@ No command or skill changes needed — the skill reads the catalog at runtime.
 │   └── spec.md                 # Spec template with YAML frontmatter
 ├── scripts/
 │   ├── setup.sh                # Wizard invoked by `spec-init`
-│   └── install-global.sh       # Symlinks setup.sh as `spec-init`
+│   ├── install-global.sh       # Symlinks setup.sh as `spec-init`
+│   ├── install-hook.sh         # Injects auto-update hook into shell profile
+│   └── check-update.sh         # Auto-update check run by the shell hook
 ├── CLAUDE.md
 ├── LICENSE
 └── README.md
@@ -198,7 +208,7 @@ your-project/
 
 ## 🔔 Auto-Update Check
 
-The setup wizard offers to add an update check hook to your shell profile. When a new terminal session opens, the hook silently checks whether the upstream repository has a newer commit. If one is found, it prints a one-line notification and asks for confirmation before applying anything.
+Run `scripts/install-hook.sh` once after cloning (see [Install step 3](#3-optional-enable-auto-update-checks-on-terminal-open)). When a new terminal session opens, the hook silently checks whether the upstream repository has a newer commit. If one is found, it prints a one-line notification and asks for confirmation before applying anything.
 
 The check:
 - runs at most once per 24 hours (cooldown stored in `~/.sdd/.last_update_check`)
@@ -208,7 +218,7 @@ The check:
 
 ### Manual installation
 
-If you declined the wizard prompt or want to add the hook yourself:
+If you prefer to add the hook line yourself rather than running `install-hook.sh`:
 
 **zsh** — add to `~/.zshrc`:
 
@@ -222,7 +232,7 @@ If you declined the wizard prompt or want to add the hook yourself:
 [ -x "/path/to/ai-spec-dev-kit/scripts/check-update.sh" ] && "/path/to/ai-spec-dev-kit/scripts/check-update.sh"
 ```
 
-Replace `/path/to/ai-spec-dev-kit` with the absolute path to your clone. The wizard injects this line automatically with the correct path when you answer **y** to the prompt.
+Replace `/path/to/ai-spec-dev-kit` with the absolute path to your clone.
 
 ---
 

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# check-update.sh — checks for ai-spec-dev-kit updates on terminal open.
+# Silent on all failures; must not block shell startup.
+
+SCRIPT_PATH="$0"
+while [ -L "$SCRIPT_PATH" ]; do
+  link=$(readlink "$SCRIPT_PATH")
+  case "$link" in
+    /*) SCRIPT_PATH="$link" ;;
+    *)  SCRIPT_PATH="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)/$link" ;;
+  esac
+done
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
+
+COOLDOWN_FILE="$HOME/.sdd/.last_update_check"
+COOLDOWN_SECONDS=86400
+
+_check_update() {
+  # Cooldown: skip if checked within 24 hours
+  if [ -f "$COOLDOWN_FILE" ]; then
+    last=$(cat "$COOLDOWN_FILE" 2>/dev/null) || return 0
+    now=$(date +%s 2>/dev/null) || return 0
+    elapsed=$((now - last))
+    if [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+      return 0
+    fi
+  fi
+
+  # Must be a git repo with a valid HEAD
+  git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1 || return 0
+
+  # Only run for GitHub remotes (HTTPS or SSH)
+  remote_url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null) || return 0
+  case "$remote_url" in
+    https://github.com/*|git@github.com:*) ;;
+    *) return 0 ;;
+  esac
+
+  # Fetch remote HEAD SHA in background with a 5-second timeout
+  tmp_sha=$(mktemp 2>/dev/null) || return 0
+  (git -C "$REPO_ROOT" ls-remote origin HEAD 2>/dev/null | awk '{print $1}' > "$tmp_sha") &
+  fetch_pid=$!
+
+  i=0
+  while [ $i -lt 5 ]; do
+    sleep 1
+    kill -0 "$fetch_pid" 2>/dev/null || break
+    i=$((i + 1))
+  done
+
+  if kill -0 "$fetch_pid" 2>/dev/null; then
+    kill "$fetch_pid" 2>/dev/null || true
+    rm -f "$tmp_sha"
+    return 0
+  fi
+  wait "$fetch_pid" 2>/dev/null || true
+
+  remote_sha=$(cat "$tmp_sha" 2>/dev/null) || true
+  rm -f "$tmp_sha"
+  [ -n "$remote_sha" ] || return 0
+
+  local_sha=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || return 0
+  [ -n "$local_sha" ] || return 0
+
+  # Record the check time regardless of update availability
+  mkdir -p "$HOME/.sdd" 2>/dev/null || true
+  date +%s > "$COOLDOWN_FILE" 2>/dev/null || true
+
+  # No update available
+  [ "$local_sha" != "$remote_sha" ] || return 0
+
+  local_short="${local_sha:0:7}"
+  remote_short="${remote_sha:0:7}"
+
+  printf '\nai-spec-dev-kit update available: %s -> %s\n' "$local_short" "$remote_short"
+  printf 'Type "update" to apply, or press Enter to skip: '
+  read -r answer < /dev/tty || return 0
+
+  [ "$answer" = "update" ] || return 0
+
+  if git -C "$REPO_ROOT" pull 2>&1; then
+    new_sha=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || true
+    printf 'Updated to %s.\n' "${new_sha:0:7}"
+  else
+    printf 'Update failed. Try: git -C "%s" pull\n' "$REPO_ROOT"
+  fi
+}
+
+_check_update || true

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# install-hook.sh — injects the ai-spec-dev-kit auto-update hook into your shell profile.
+#
+# Usage:
+#   /path/to/ai-spec-dev-kit/scripts/install-hook.sh
+#
+# Detects your shell from $SHELL, resolves the profile (~/.zshrc or ~/.bash_profile),
+# and appends a one-line hook that runs check-update.sh on each new terminal session.
+# Safe to re-run — the hook line is injected only once (idempotent).
+#
+# Compatible with macOS default bash (3.2) and Linux.
+
+set -eu
+
+resolve_path() {
+  target="$1"
+  while [ -L "$target" ]; do
+    link=$(readlink "$target")
+    case "$link" in
+      /*) target="$link" ;;
+      *)  target="$(cd "$(dirname "$target")" && pwd)/$link" ;;
+    esac
+  done
+  cd "$(dirname "$target")" && printf '%s\n' "$(pwd)/$(basename "$target")"
+}
+
+SCRIPT_PATH="$(resolve_path "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$REPO_ROOT/scripts/check-update.sh"
+
+if [ ! -f "$CHECK_SCRIPT" ]; then
+  echo "Error: cannot find $CHECK_SCRIPT" >&2
+  exit 1
+fi
+
+chmod +x "$CHECK_SCRIPT"
+
+# Detect shell profile.
+case "$SHELL" in
+  */zsh)  PROFILE="$HOME/.zshrc" ;;
+  */bash) PROFILE="$HOME/.bash_profile" ;;
+  *)      PROFILE="$HOME/.zshrc" ;;
+esac
+
+HOOK_LINE="[ -x \"$CHECK_SCRIPT\" ] && \"$CHECK_SCRIPT\""
+
+# Check if already installed.
+if [ -f "$PROFILE" ] && grep -Fxq "$HOOK_LINE" "$PROFILE"; then
+  echo "Hook already present in $PROFILE — nothing to do."
+  exit 0
+fi
+
+# Inject the hook line.
+if [ -w "$PROFILE" ] || [ ! -e "$PROFILE" ]; then
+  # Guard: ensure trailing newline before appending.
+  if [ -s "$PROFILE" ] && [ "$(tail -c 1 "$PROFILE" | wc -l)" -eq 0 ]; then
+    printf '\n' >> "$PROFILE"
+  fi
+  printf '%s\n' "$HOOK_LINE" >> "$PROFILE"
+  echo "Installed update check hook in $PROFILE"
+  echo
+  echo "Open a new terminal session (or run: source $PROFILE) to activate."
+else
+  echo "Cannot write to $PROFILE — add this line manually:"
+  echo
+  echo "  $HOOK_LINE"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -134,6 +134,21 @@ ensure_gitignore_line() {
   fi
 }
 
+ensure_profile_line() {
+  profile="$1"
+  line="$2"
+  if [ ! -f "$profile" ]; then
+    printf '%s\n' "$line" > "$profile"
+    return
+  fi
+  if ! grep -Fxq "$line" "$profile"; then
+    if [ -s "$profile" ] && [ "$(tail -c 1 "$profile" | wc -l)" -eq 0 ]; then
+      printf '\n' >> "$profile"
+    fi
+    printf '%s\n' "$line" >> "$profile"
+  fi
+}
+
 copy_dir_contents() {
   src="$1"
   dst="$2"
@@ -204,6 +219,21 @@ if [ "$JIRA_ENABLED" = "true" ]; then
 fi
 
 echo
+echo "Auto-update check"
+echo "-----------------"
+echo "The toolkit can check for updates each time you open a new terminal session."
+echo "It runs silently in the background and only prompts when an update is available."
+
+case "$SHELL" in
+  */zsh)  SHELL_PROFILE="$HOME/.zshrc" ;;
+  */bash) SHELL_PROFILE="$HOME/.bash_profile" ;;
+  *)      SHELL_PROFILE="$HOME/.zshrc" ;;
+esac
+
+HOOK_LINE="[ -x \"$REPO_ROOT/scripts/check-update.sh\" ] && \"$REPO_ROOT/scripts/check-update.sh\""
+INSTALL_HOOK=$(prompt_yn "Add update check hook to $SHELL_PROFILE?" "y")
+
+echo
 echo "Version control"
 echo "---------------"
 echo "The toolkit directories can be kept local-only (gitignored) or committed."
@@ -262,6 +292,15 @@ if [ "$GITIGNORE_TOOLKIT" = "true" ]; then
   ensure_gitignore_line ".claude/skills/"
 fi
 echo "  updated $DST_GITIGNORE"
+
+if [ "$INSTALL_HOOK" = "true" ]; then
+  ensure_profile_line "$SHELL_PROFILE" "$HOOK_LINE"
+  echo "  added update check hook to $SHELL_PROFILE"
+else
+  echo
+  echo "To enable update checks manually, add this line to your shell profile:"
+  echo "  $HOOK_LINE"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -134,21 +134,6 @@ ensure_gitignore_line() {
   fi
 }
 
-ensure_profile_line() {
-  profile="$1"
-  line="$2"
-  if [ ! -f "$profile" ]; then
-    printf '%s\n' "$line" > "$profile"
-    return
-  fi
-  if ! grep -Fxq "$line" "$profile"; then
-    if [ -s "$profile" ] && [ "$(tail -c 1 "$profile" | wc -l)" -eq 0 ]; then
-      printf '\n' >> "$profile"
-    fi
-    printf '%s\n' "$line" >> "$profile"
-  fi
-}
-
 copy_dir_contents() {
   src="$1"
   dst="$2"
@@ -219,21 +204,6 @@ if [ "$JIRA_ENABLED" = "true" ]; then
 fi
 
 echo
-echo "Auto-update check"
-echo "-----------------"
-echo "The toolkit can check for updates each time you open a new terminal session."
-echo "It runs silently in the background and only prompts when an update is available."
-
-case "$SHELL" in
-  */zsh)  SHELL_PROFILE="$HOME/.zshrc" ;;
-  */bash) SHELL_PROFILE="$HOME/.bash_profile" ;;
-  *)      SHELL_PROFILE="$HOME/.zshrc" ;;
-esac
-
-HOOK_LINE="[ -x \"$REPO_ROOT/scripts/check-update.sh\" ] && \"$REPO_ROOT/scripts/check-update.sh\""
-INSTALL_HOOK=$(prompt_yn "Add update check hook to $SHELL_PROFILE?" "y")
-
-echo
 echo "Version control"
 echo "---------------"
 echo "The toolkit directories can be kept local-only (gitignored) or committed."
@@ -292,15 +262,6 @@ if [ "$GITIGNORE_TOOLKIT" = "true" ]; then
   ensure_gitignore_line ".claude/skills/"
 fi
 echo "  updated $DST_GITIGNORE"
-
-if [ "$INSTALL_HOOK" = "true" ]; then
-  ensure_profile_line "$SHELL_PROFILE" "$HOOK_LINE"
-  echo "  added update check hook to $SHELL_PROFILE"
-else
-  echo
-  echo "To enable update checks manually, add this line to your shell profile:"
-  echo "  $HOOK_LINE"
-fi
 
 # ---------------------------------------------------------------------------
 # Summary.


### PR DESCRIPTION
## Summary

- Adds \`scripts/check-update.sh\` — silent background update checker with 24h cooldown, 5-second \`git ls-remote\` timeout, SHA comparison, and \`"update"\` confirmation prompt before applying \`git pull\`
- Adds \`scripts/install-hook.sh\` — standalone one-time installer that detects your shell profile (\`~/.zshrc\` / \`~/.bash_profile\`) and injects the hook line idempotently; mirrors the \`install-global.sh\` pattern
- Updates \`README.md\` — new Install step 3 for \`install-hook.sh\`, refreshed "Auto-Update Check" section, updated repo layout

Hook injection was moved out of \`setup.sh\` into \`install-hook.sh\`: profile setup is a one-time developer machine operation, not a per-project wizard question.

## Test plan

- [x] Run \`scripts/install-hook.sh\` — verify hook line injected into shell profile
- [x] Run \`scripts/install-hook.sh\` again — verify idempotent (no duplicate line)
- [x] Run \`scripts/setup.sh\` in a throwaway directory — confirm no hook prompt appears
- [x] \`echo 0 > ~/.sdd/.last_update_check\` then invoke \`check-update.sh\` — verify cooldown expires and remote check runs
- [x] Invoke \`check-update.sh\` a second time immediately — verify cooldown prevents a second check
- [x] Simulate network unavailability — verify no error output and script exits within ~5 seconds
- [x] Simulate update available (local SHA differs from remote) — verify notification and prompt appear
- [x] Decline update prompt — verify no changes applied
- [x] Confirm update prompt — verify \`git pull\` runs and new SHA is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)