### PR TITLE
SDD-3: Usability Improvements

### DIFF
--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -54,7 +54,12 @@ Type any feedback to request changes before committing.
 
 - `continue` → go to step 6.
 - `abort` → stop immediately, do not commit, print how many steps remain.
-- Anything else → treat as feedback. Apply changes, re-show the pause prompt (step 4). Loop until `continue` or `abort`.
+- Anything else → treat as feedback:
+  1. Apply the requested changes.
+  2. Re-display the §4 pause prompt **byte-identical** to the first display (same wording, same border lines, updated "Files changed" and "Summary" if the changes affected them).
+  3. Wait for user response. Loop indefinitely until `continue` or `abort`.
+
+  The prompt re-display is mandatory after every feedback round, regardless of how many iterations the loop has run.
 
 ### 6. Commit and mark done
 

--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -73,6 +73,18 @@ Type any feedback to request changes before committing.
 
 Back to step 2. Repeat until done.
 
+### 7a. CLAUDE.md update
+
+Runs once, after all steps are checked/superseded, **only if at least one step was committed in this run.**
+
+1. Assess whether the completed build introduced behaviors, invariants, commands, or architectural facts that belong in the target's `CLAUDE.md`.
+2. If `CLAUDE.md` is absent in the project root → skip entirely.
+3. If no CLAUDE.md-worthy changes were introduced → skip entirely (do not create a no-op commit).
+4. Otherwise:
+   - Edit `CLAUDE.md` to reflect the new facts (new commands, changed invariants, updated tail behaviors, etc.).
+   - Commit: `<spec_id>: update CLAUDE.md with new behaviors`
+5. Then proceed to §8.
+
 ### 8. Completion
 
 All checked or superseded:

--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -1,7 +1,7 @@
 ---
 description: Build (implement) a planned spec step by step, pausing for review before each commit
 argument-hint: "SPEC-123"
-allowed-tools: Read, Write, Glob, Grep, Bash
+allowed-tools: Read, Write, Glob, Grep, Bash, Bash(git push:*), Bash(gh pr create:*), Bash(gh pr edit:*), Bash(gh pr view:*), Bash(gh pr list:*)
 ---
 
 Build a previously planned spec. Work one step at a time, pause after each for user review before committing. Adhere to CLAUDE.md.
@@ -94,14 +94,49 @@ All checked or superseded:
    - Skill handles drift detection, user confirmation, frontmatter stripping, cache update.
    - Capture result: `pushed | aborted by user | skipped (conflict unresolved)`.
 
-2. Print:
+2. **Push / PR prompt.** Print:
+
+   ```
+   ──────────────────────────────────────
+   Ready to push branch: <branch>
+
+   Type "push" to push the branch to origin.
+   Type "push + PR" to push and create or update a pull request.
+   Type "skip" to exit without touching the remote.
+   ──────────────────────────────────────
+   ```
+
+   **STOP. Wait for user.**
+
+   - `skip` → print `Branch <branch> is ready locally. No remote changes made.` and proceed to step 3.
+   - `push` → run `git push -u origin <branch>`. On success print the remote URL. On failure print the error verbatim and proceed to step 3.
+   - `push + PR`:
+     1. Run `git push -u origin <branch>`. On push failure print the error verbatim and proceed to step 3 (do not attempt PR).
+     2. Check whether an open PR already tracks this branch: `gh pr list --head <branch> --state open --json number,url`.
+        - Open PR found → run `gh pr edit <number> --body "<auto-body>"`.
+        - No open PR → run `gh pr create --title "<spec_title>" --body "<auto-body>"`.
+     3. Auto-body format:
+        ```
+        ## Summary
+        <spec Summary section verbatim>
+
+        ## Commits
+        <output of: git log origin/main..<branch> --oneline>
+
+        🤖 Generated with [Claude Code](https://claude.com/claude-code)
+        ```
+     4. On `gh` success print the PR URL.
+     5. On `gh` failure (not installed, not authenticated, etc.): keep the push, print the error verbatim, and print the equivalent manual command the user can run.
+
+3. Print:
    ```
    ──────────────────────────────────────
    Build complete: <spec_id>
    Branch:  <current branch>
    Commits: <number of steps completed>
    Source:  <skipped|pushed to <source>:<source_ref>|aborted by user>
+   Remote:  <skipped|pushed|pushed + PR <url>|push failed>
    ──────────────────────────────────────
    ```
 
-3. Remind user to run the QA pipeline from CLAUDE.md if the last step didn't already cover it.
+4. Remind user to run the QA pipeline from CLAUDE.md if the last step didn't already cover it.

--- a/ai/claude/commands/spec-plan.md
+++ b/ai/claude/commands/spec-plan.md
@@ -62,6 +62,23 @@ Present:
 2. Technical decisions with multiple valid approaches — describe options, ask user to choose.
 3. Risks needing user input.
 
+**Option suggestions:** For each open question or decision where options can be reasonably inferred, propose 2–4 candidate answers and mark one as the default. Use this format:
+
+```
+Q: <question text>
+  ★ (a) <option> — <one-line reason>  ← default
+    (b) <option> — <one-line reason>
+    (c) <option> — <one-line reason>
+```
+
+Infer options using this source-of-truth order:
+1. Spec body (existing constraints or examples).
+2. Codebase (closest analogous pattern already implemented).
+3. Prior specs / `CLAUDE.md` (established conventions).
+4. Generic defaults (common industry practice).
+
+When no options are reasonably inferable from any of the above, ask the question open-ended without fabricated options.
+
 **STOP and wait for answers.** Do not proceed until user responds.
 
 ### 7. Write/refresh spec sections


### PR DESCRIPTION
## Summary

Improve the ergonomics of `/spec-plan` and `/spec-build` so they guide the user more actively: suggest likely answers for open questions, re-prompt step completion after applying feedback, update `CLAUDE.md` at the end of a build, and offer to push and create/update a PR on completion.

## Commits

95ca184 SDD-3: step 6 - QA setup.sh against throwaway dir, all new wording verified
fedf0a1 SDD-3: step 5 - update CLAUDE.md with new lifecycle facts and invariants
794188b SDD-3: step 4 - add three-way push/PR prompt to spec-build §8 Completion
88bb4a5 SDD-3: step 3 - add CLAUDE.md-update action (§7a) to spec-build
1f098b8 SDD-3: step 2 - make feedback-reprompt loop explicit in spec-build §5
1439a6e SDD-3: step 1 - extend spec-plan §6 with option-suggestion guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)