### PR TITLE
SDD-4: Make Having Claude As A Collaborator In Commits And PR Optional

### DIFF
--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -18,6 +18,8 @@ User input: $ARGUMENTS
 
 Read `.sdd/specs/<spec_id>.md`. Parse frontmatter (`source`, `source_ref`). Body must contain an `## Implementation Plan` section with checkboxes. Missing → tell user to run `/spec-plan <spec_id>` first and stop.
 
+Read `.sdd/config.json`. Extract `claude_attribution` (top-level boolean field). If the field is absent, non-boolean, or `config.json` is missing, default to `true`. Store as `CLAUDE_ATTRIBUTION` for use in §6 and §8.
+
 ### 2. Find next step
 
 First unchecked step (`- [ ]`). Superseded steps (`- [x] ~~...~~ _(superseded: ...)_`) count as done — skip. All checked or superseded → go to **Completion**.
@@ -65,6 +67,8 @@ Type any feedback to request changes before committing.
 
 1. `git add -A`
 2. Commit: `<spec_id>: step N - <short step description>`
+   - If `CLAUDE_ATTRIBUTION` is `true`: include a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer in the commit message body.
+   - If `CLAUDE_ATTRIBUTION` is `false`: do **not** append any `Co-Authored-By` trailer. Pass the full commit message explicitly and do not add attribution.
 3. Update spec: change `- [ ] Step N:` to `- [x] Step N:` for the completed step.
 4. `git add .sdd/specs/<spec_id>.md && git commit --amend --no-edit`
 5. Print: `✓ Step N committed. Moving to next step...`
@@ -125,6 +129,7 @@ All checked or superseded:
 
         🤖 Generated with [Claude Code](https://claude.com/claude-code)
         ```
+        If `CLAUDE_ATTRIBUTION` is `false`, omit the `🤖 Generated with [Claude Code](https://claude.com/claude-code)` line.
      4. On `gh` success print the PR URL.
      5. On `gh` failure (not installed, not authenticated, etc.): keep the push, print the error verbatim, and print the equivalent manual command the user can run.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -191,6 +191,7 @@ echo "--------------------"
 JIRA_ENABLED=$(prompt_yn "Enable Jira as a spec source?" "n")
 JIRA_PROJECT_KEY=""
 JIRA_WORKSPACE=""
+CLAUDE_ATTRIBUTION=$(prompt_yn "Include Claude as a co-author in commits and PR bodies?" "y")
 
 if [ "$JIRA_ENABLED" = "true" ]; then
   if ! command -v acli >/dev/null 2>&1; then
@@ -239,6 +240,7 @@ echo "  wrote $DST_TEMPLATE_DIR/spec.md"
 # Config.
 cat > "$DST_CONFIG" <<EOF
 {
+  "claude_attribution": $CLAUDE_ATTRIBUTION,
   "sources": {
     "local": {
       "enabled": true,
@@ -272,6 +274,7 @@ cat <<EOF
 ────────────────────────────────────────────────────
 Done.
 
+Claude attribution: $CLAUDE_ATTRIBUTION
 Enabled sources:
   local: true
   jira:  $JIRA_ENABLED


### PR DESCRIPTION
## Summary

Allow users to opt out of Claude co-author attribution in commits and pull requests generated by the SDD toolkit. A single configuration flag (stored in `.sdd/config.json`) controls the behavior. When attribution is disabled, `/spec-build` omits the `Co-Authored-By` trailer from commits and the Claude attribution line from PR bodies. Default behavior (attribution on) is preserved for backwards compatibility.

## Commits

ea79606 SDD-4: step 2 - read claude_attribution in spec-build; conditionally suppress Co-Authored-By and PR footer
c9cbaae SDD-4: step 1 - add CLAUDE_ATTRIBUTION prompt and config.json field to setup.sh