### PR TITLE
SDD-12: Refactor spec-caveman skill with auto-applied compression modes

### DIFF
--- a/ai/claude/skills/spec-caveman/SKILL.md
+++ b/ai/claude/skills/spec-caveman/SKILL.md
@@ -6,7 +6,6 @@ description: >
   questions, or responds to pause prompts mid-lifecycle, or when context references
   .sdd/, the spec-source skill, Implementation Plan, or Acceptance Criteria.
   Never touches code, commit messages, PR bodies, or verbatim interactive prompts.
-  Two modes auto-applied by output type: lite (default, keeps articles/grammar) and full (drops articles, fragments OK, informative prose only).
 ---
 
 All SDD prose compressed. Substance stays. Fluff dies.

--- a/ai/claude/skills/spec-caveman/SKILL.md
+++ b/ai/claude/skills/spec-caveman/SKILL.md
@@ -6,47 +6,42 @@ description: >
   questions, or responds to pause prompts mid-lifecycle, or when context references
   .sdd/, the spec-source skill, Implementation Plan, or Acceptance Criteria.
   Never touches code, commit messages, PR bodies, or verbatim interactive prompts.
-  Two modes: lite (default, all output) and full (drops articles, fragments OK, informative prose only).
+  Two modes auto-applied by output type: lite (default, keeps articles/grammar) and full (drops articles, fragments OK, informative prose only).
 ---
 
-All SDD prose → compressed. Technical substance stay. Fluff die.
+All SDD prose compressed. Substance stays. Fluff dies.
 
 ## Persistence
 
 Active full lifecycle. Off only: user leaves SDD flow.
 
-Default **lite**.
+Mode auto-selected per output type — not user-toggled.
 
-## Lite (default)
+## Rules
 
-All output — spec prose (summaries, analysis, clarifications, plans) included. Stay lite even on "what?" / repeats.
-
-Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course), hedging (I think maybe / perhaps we could).
-Keep: articles, full sentences, subject+verb. Professional but tight.
+Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course), hedging (I think maybe / perhaps we could). Tech terms exact. Code blocks untouched. Errors verbatim.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
-- No: "Sure! I'd be happy to help. The issue is likely a stale cache."
-- Yes: "Stale cache. Clear `.sdd/specs/.cache/<id>.jira.md`, re-run `/spec-plan`."
+- No: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by a stale cache."
+- Yes (lite): "The issue is a stale cache. Clear `.sdd/specs/.cache/<id>.jira.md` and re-run `/spec-plan`."
+- Yes (full): "Stale cache. Clear `.sdd/specs/.cache/<id>.jira.md`, re-run `/spec-plan`."
 
-Tech terms exact. Code blocks untouched. Errors verbatim.
+## Modes
 
-## Full
+Auto-applied per output type:
 
-Informative non-code prose only (explanations, rationale, option descriptions, status). Falls back → **lite** on "what?" / repeats.
-
-Drop: articles (a/an/the), filler, pleasantries, hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for").
-
-- Lite: "The component re-renders because you create a new object reference each render."
-- Full: "New object ref each render → re-render."
-
-Tech terms exact. Code blocks untouched. Errors verbatim.
+| Mode | When | Rules |
+|------|------|-------|
+| **full** | Informative non-code prose (explanations, rationale, option descriptions, status summaries) | Drop articles, fragments OK, short synonyms |
+| **lite** | Everything else (spec content being written, direct answers, clarifications, user asked "what?" / repeated) | Keep articles, full sentences, subject+verb. Professional tight |
 
 ## Never compress
 
 - Security warnings, irreversible confirmations, multi-step sequences where fragment order risks misread
-- Tool errors (`acli`, `git`, `bash`) — exact
+- Tool errors (`acli`, `git`, `bash` or other CLI tools) — exact
 - Interactive prompts (`Type "continue"...`), `──────────` border blocks
-- Code, diffs, frontmatter, source file contents (spec prose compressible, source files not)
+- Code, diffs, frontmatter (including spec frontmatter), source file contents
+- Spec prose is compressible; source files and frontmatter are not
 - Git commit messages (subject + body + `Co-Authored-By`)
 - PR titles and bodies

--- a/ai/claude/skills/spec-caveman/SKILL.md
+++ b/ai/claude/skills/spec-caveman/SKILL.md
@@ -9,49 +9,44 @@ description: >
   Two modes: lite (default, all output) and full (drops articles, fragments OK, informative prose only).
 ---
 
-Compress all user-facing prose in SDD commands. Technical substance stays. Fluff dies.
+All SDD prose → compressed. Technical substance stay. Fluff die.
 
 ## Persistence
 
-Active for full command lifecycle. Deactivate only on: "stop caveman", "normal mode", final summary block, or user leaving SDD flow.
+Active full lifecycle. Off only: user leaves SDD flow.
 
-Default: **lite**. Switch: user says `full` or `lite`.
+Default **lite**.
 
-## Modes
+## Lite (default)
 
-### Lite (default)
+All output — spec prose (summaries, analysis, clarifications, plans) included. Stay lite even on "what?" / repeats.
 
-Applied to **all** output — including spec file prose (summaries, analysis, clarifications, plan descriptions). Stays active even when user asks "what?" or repeats.
-
-Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course), hedging (I think maybe / perhaps we could / it might be).
-
-Keep: articles, full sentences, subject+verb grammar. Professional, tight.
+Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course), hedging (I think maybe / perhaps we could).
+Keep: articles, full sentences, subject+verb. Professional but tight.
 
 Pattern: `[thing] [action] [reason]. [next step].`
 
 - No: "Sure! I'd be happy to help. The issue is likely a stale cache."
-- Yes: "The issue is a stale cache. Clear `.sdd/specs/.cache/<id>.jira.md` and re-run `/spec-plan`."
+- Yes: "Stale cache. Clear `.sdd/specs/.cache/<id>.jira.md`, re-run `/spec-plan`."
 
-Technical terms exact. Code blocks unchanged. Errors quoted verbatim.
+Tech terms exact. Code blocks untouched. Errors verbatim.
 
-### Full
+## Full
 
-Applied to informative non-code prose during the spec lifecycle (explanations, analysis rationale, option descriptions, status summaries). Falls back to **lite** when user asks "what?" or repeats.
+Informative non-code prose only (explanations, rationale, option descriptions, status). Falls back → **lite** on "what?" / repeats.
 
 Drop: articles (a/an/the), filler, pleasantries, hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for").
-
-Pattern: `[thing] [action] [reason]. [next step].`
 
 - Lite: "The component re-renders because you create a new object reference each render."
 - Full: "New object ref each render → re-render."
 
-Technical terms exact. Code blocks unchanged. Errors quoted verbatim.
+Tech terms exact. Code blocks untouched. Errors verbatim.
 
 ## Never compress
 
-- Security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread
-- Tool errors (`acli`, `git`, `bash`) — quote exact
-- Interactive prompt strings (`Type "continue"...`), `──────────` border blocks
-- Code, diffs, frontmatter, source code file contents (spec prose is compressible, source files are not)
-- Git commit messages (subject + body + `Co-Authored-By` footer)
+- Security warnings, irreversible confirmations, multi-step sequences where fragment order risks misread
+- Tool errors (`acli`, `git`, `bash`) — exact
+- Interactive prompts (`Type "continue"...`), `──────────` border blocks
+- Code, diffs, frontmatter, source file contents (spec prose compressible, source files not)
+- Git commit messages (subject + body + `Co-Authored-By`)
 - PR titles and bodies

--- a/ai/claude/skills/spec-caveman/SKILL.md
+++ b/ai/claude/skills/spec-caveman/SKILL.md
@@ -1,20 +1,27 @@
 ---
 name: spec-caveman
 description: >
-  Terse lite-level response style for SDD commands (/spec-draft, /spec-plan, /spec-build,
+  Terse response style for SDD commands (/spec-draft, /spec-plan, /spec-build,
   /spec-status). Auto-activates during those commands and when user gives feedback, answers
   questions, or responds to pause prompts mid-lifecycle, or when context references
   .sdd/, the spec-source skill, Implementation Plan, or Acceptance Criteria.
   Never touches code, commit messages, PR bodies, or verbatim interactive prompts.
+  Two modes: lite (default, all output) and full (drops articles, fragments OK, informative prose only).
 ---
 
-Apply lite-level caveman to all user-facing prose in SDD commands. Technical substance stays. Fluff dies.
+Compress all user-facing prose in SDD commands. Technical substance stays. Fluff dies.
 
 ## Persistence
 
 Active for full command lifecycle. Deactivate only on: "stop caveman", "normal mode", final summary block, or user leaving SDD flow.
 
-## Lite rules
+Default: **lite**. Switch: user says `full` or `lite`.
+
+## Modes
+
+### Lite (default)
+
+Applied to **all** output — including spec file prose (summaries, analysis, clarifications, plan descriptions). Stays active even when user asks "what?" or repeats.
 
 Drop: filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course), hedging (I think maybe / perhaps we could / it might be).
 
@@ -27,18 +34,24 @@ Pattern: `[thing] [action] [reason]. [next step].`
 
 Technical terms exact. Code blocks unchanged. Errors quoted verbatim.
 
+### Full
+
+Applied to informative non-code prose during the spec lifecycle (explanations, analysis rationale, option descriptions, status summaries). Falls back to **lite** when user asks "what?" or repeats.
+
+Drop: articles (a/an/the), filler, pleasantries, hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for").
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+- Lite: "The component re-renders because you create a new object reference each render."
+- Full: "New object ref each render → re-render."
+
+Technical terms exact. Code blocks unchanged. Errors quoted verbatim.
+
 ## Never compress
 
-| Content | Reason |
-|---|---|
-| Git commit messages (subject + body + `Co-Authored-By` footer) | Repo convention, attribution |
-| PR titles and bodies | Templates, reviewers read full |
-| Interactive prompt strings (`Type "continue"...`) | Users need exact token |
-| `──────────` border blocks | Output contract |
-| Code, diffs, frontmatter, file contents | Substance |
-| Tool errors (`acli`, `git`, `bash`) | Quote exact |
-| Security warnings, destructive confirmations | Clarity first |
-
-## Auto-clarity overrides
-
-Drop lite momentarily when: step order risks misread, user asks "what?" / repeats, ambiguity would change user's decision. Resume after.
+- Security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread
+- Tool errors (`acli`, `git`, `bash`) — quote exact
+- Interactive prompt strings (`Type "continue"...`), `──────────` border blocks
+- Code, diffs, frontmatter, source code file contents (spec prose is compressible, source files are not)
+- Git commit messages (subject + body + `Co-Authored-By` footer)
+- PR titles and bodies


### PR DESCRIPTION
## Summary

Refactors the `spec-caveman` skill to use two auto-inferred compression modes instead of a single flat lite-level style.

## Changes

- **Two modes (full/lite)** auto-applied by output type — no user toggle needed
  - **Full**: drops articles, fragments OK, short synonyms — for informative non-code prose (explanations, rationale, option descriptions, status summaries)
  - **Lite**: keeps articles, full sentences, subject+verb — for everything else (spec content, direct answers, clarifications, confusion fallback)
- **Single shared Rules section** defining drop/pattern/examples once, modes specify only deltas
- **Never-compress list** restructured: security warnings, irreversible confirmations, and multi-step ordering risks always exempt; spec frontmatter explicitly distinguished from compressible spec prose
- **Removed auto-clarity override** — lite stays lite on confusion; full falls back to lite
- **Frontmatter description** trimmed to activation triggers only — mode details stay in the body
- **Compressed skill body** to practice what it preaches