### PR TITLE
SDD-9: Fix .sdd/ commit errors when gitignored + align caveman skill usage

### DIFF
--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -10,7 +10,7 @@ User input: $ARGUMENTS
 
 - Adapter catalog: `.sdd/sources.md`.
 - Source I/O: delegate `push`, `detect_conflict`, and cache management to the `spec-source` skill.
-- Response style: `spec-caveman` skill applies (lite; exceptions for code/commits/prompts).
+- Response style: `spec-caveman` skill applies (mode auto-selected per output type).
 
 ## Workflow
 

--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -20,6 +20,8 @@ Read `.sdd/specs/<spec_id>.md`. Parse frontmatter (`source`, `source_ref`). Body
 
 Read `.sdd/config.json`. Extract `claude_attribution` (top-level boolean field). If the field is absent, non-boolean, or `config.json` is missing, default to `true`. Store as `CLAUDE_ATTRIBUTION` for use in §6 and §8.
 
+Extract `track_specs` (top-level boolean field). If absent, non-boolean, or `config.json` is missing, default to `true`. Store as `TRACK_SPECS` for use in §6.
+
 ### 2. Find next step
 
 First unchecked step (`- [ ]`). Superseded steps (`- [x] ~~...~~ _(superseded: ...)_`) count as done — skip. All checked or superseded → go to **Completion**.
@@ -70,7 +72,8 @@ Type any feedback to request changes before committing.
    - If `CLAUDE_ATTRIBUTION` is `true`: include a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer in the commit message body.
    - If `CLAUDE_ATTRIBUTION` is `false`: do **not** append any `Co-Authored-By` trailer. Pass the full commit message explicitly and do not add attribution.
 3. Update spec: change `- [ ] Step N:` to `- [x] Step N:` for the completed step.
-4. `git add .sdd/specs/<spec_id>.md && git commit --amend --no-edit`
+4. If `TRACK_SPECS` is `true`: `git add .sdd/specs/<spec_id>.md && git commit --amend --no-edit`
+   If `TRACK_SPECS` is `false`: skip — the checkbox update lives on disk only.
 5. Print: `✓ Step N committed. Moving to next step...`
 
 ### 7. Loop

--- a/ai/claude/commands/spec-draft.md
+++ b/ai/claude/commands/spec-draft.md
@@ -11,7 +11,7 @@ User input: $ARGUMENTS
 - Enabled sources: `.sdd/config.json`.
 - Adapter catalog: `.sdd/sources.md`.
 - Source I/O: delegate `pull`, `adapt`, and cache management to the `spec-source` skill.
-- Response style: `spec-caveman` skill applies (lite; exceptions for code/commits/prompts).
+- Response style: `spec-caveman` skill applies (mode auto-selected per output type).
 
 ## Workflow
 

--- a/ai/claude/commands/spec-draft.md
+++ b/ai/claude/commands/spec-draft.md
@@ -36,12 +36,15 @@ Check whether `.sdd/specs/<spec_id>.md` exists.
 - **Exists** → refresh mode. Skip branch creation. Refresh body and commit as a standalone commit.
 - **Missing** → new draft mode. Do dirty tree check and create branch.
 
+Read `.sdd/config.json`. Extract `track_specs` (top-level boolean field). If absent, non-boolean, or `config.json` is missing, default to `true`. Store as `TRACK_SPECS`.
+
 ### 3. Dirty tree check
 
 Run `git status --porcelain`.
 
 - New draft: non-empty → abort, ask user to commit or stash.
 - Refresh: anything other than `.sdd/specs/<spec_id>.md` → abort.
+- When `TRACK_SPECS` is `false`: `.sdd/` files are gitignored and will not appear in `git status` output. Only non-ignored dirty files matter for the check.
 
 ### 4. Choose source
 
@@ -90,10 +93,13 @@ No implementation details, code examples, or file paths — product-level docume
 
 Refresh mode, after writing:
 
+If `TRACK_SPECS` is `true`:
 ```
 git add .sdd/specs/<spec_id>.md .sdd/specs/.cache/<spec_id>.<source>.md 2>/dev/null
 git commit -m "<spec_id>: refresh spec from <source>"
 ```
+
+If `TRACK_SPECS` is `false`: skip — the spec update lives on disk only.
 
 New draft: leave uncommitted — user commits after review.
 

--- a/ai/claude/commands/spec-plan.md
+++ b/ai/claude/commands/spec-plan.md
@@ -10,7 +10,7 @@ User input: $ARGUMENTS
 
 - Adapter catalog: `.sdd/sources.md`.
 - Source I/O: delegate `push`, `detect_conflict`, and cache management to the `spec-source` skill.
-- Response style: `spec-caveman` skill applies (lite; exceptions for code/commits/prompts).
+- Response style: `spec-caveman` skill applies (mode auto-selected per output type).
 
 ## Workflow
 

--- a/ai/claude/commands/spec-status.md
+++ b/ai/claude/commands/spec-status.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Glob, Bash(git branch:*), Bash(git rev-parse:*), Bash(ls:*)
 
 Report the state of one or more specs. **Read-only**: do not modify files, do not call external services (no `acli`, no network).
 
-Response style: `spec-caveman` skill applies (lite; exceptions for code/commits/prompts).
+Response style: `spec-caveman` skill applies (mode auto-selected per output type).
 
 User input: $ARGUMENTS
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -235,6 +235,13 @@ echo "---------------"
 echo "The toolkit directories can be kept local-only (gitignored) or committed."
 GITIGNORE_TOOLKIT=$(prompt_yn "Exclude toolkit from version control (.sdd/, .claude/commands/, .claude/skills/)?" "n")
 
+# Derive track_specs (inverse of GITIGNORE_TOOLKIT) for config.json.
+if [ "$GITIGNORE_TOOLKIT" = "true" ]; then
+  TRACK_SPECS=false
+else
+  TRACK_SPECS=true
+fi
+
 # ---------------------------------------------------------------------------
 # Apply.
 # ---------------------------------------------------------------------------
@@ -266,6 +273,7 @@ echo "  wrote $DST_TEMPLATE_DIR/spec.md"
 cat > "$DST_CONFIG" <<EOF
 {
   "claude_attribution": $CLAUDE_ATTRIBUTION,
+  "track_specs": $TRACK_SPECS,
   "sources": {
     "local": {
       "enabled": true,


### PR DESCRIPTION
## Summary

When the `spec-init` wizard gitignores `.sdd/`, the spec commands still tried to `git add` and commit `.sdd/` paths, causing errors. This adds a `track_specs` config field so commands know whether to commit spec files.

Also fixes all four commands hardcoding `(lite)` mode for the caveman skill, overriding the auto-applied mode selection from PR #13.

## Changes

- `setup.sh`: derives `track_specs` (inverse of `GITIGNORE_TOOLKIT`) and writes it to `config.json`
- `spec-build.md`: reads `track_specs`; skips `git add .sdd/` + amend when `false`
- `spec-draft.md`: reads `track_specs`; skips refresh commit when `false`; adjusts dirty-tree check
- All four commands: removed hardcoded `(lite; ...)` caveman override, now defer to skill's auto mode selection

## Commits
0efe1e0 fix: stop overriding caveman skill auto-applied modes in commands
d5a1327 feat: add track_specs config to skip .sdd/ commits when gitignored
