### PR TITLE
SDD-10: Single-source selection during spec-init

### DIFF
--- a/ai/claude/commands/spec-draft.md
+++ b/ai/claude/commands/spec-draft.md
@@ -48,12 +48,10 @@ Run `git status --porcelain`.
 
 ### 4. Choose source
 
-Read `.sdd/config.json`, list sources with `enabled: true`.
+Read `.sdd/config.json`, extract the top-level `source` field (one of `local`, `jira`, `youtrack`). If absent or not a recognised value, default to `local`.
 
-- Only `local` enabled → `source = local`, skip to step 6.
-- Otherwise → ask user to pick.
-
-Non-local source → ask for `source_ref` if different from `spec_id`. Default: `source_ref = spec_id`.
+- `source == "local"` → skip to step 6.
+- Otherwise → use the selected source. Ask for `source_ref` if different from `spec_id`. Default: `source_ref = spec_id`.
 
 ### 5. Pull and adapt (skill)
 

--- a/ai/claude/skills/spec-source/SKILL.md
+++ b/ai/claude/skills/spec-source/SKILL.md
@@ -7,7 +7,7 @@ description: Pull, adapt, push, and detect drift for specs stored in external sy
 
 Unified adapter for reading and writing specs across multiple backends. Used by `/spec-draft`, `/spec-plan`, `/spec-build`.
 
-Adapter catalog: `.sdd/sources.md`. Config: `.sdd/config.json`.
+Adapter catalog: `.sdd/sources.md`. Config: `.sdd/config.json` (top-level `source` field selects the active adapter; per-adapter settings under `sources`).
 
 ## Operations
 
@@ -78,5 +78,5 @@ Checks for external drift since the last known sync.
 ## Adding an adapter
 
 1. Add a section in `.sdd/sources.md` with wire calls for `pull` and `push`.
-2. Add a key under `sources` in `.sdd/config.json` with its config (project key, workspace, token env, etc.).
+2. Add a key under `sources` in `.sdd/config.json` with its config (project key, workspace, token env, etc.). The user selects the adapter during `spec-init` via the top-level `source` field.
 3. No skill or command changes needed — this skill reads the catalog at runtime.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -187,13 +187,33 @@ fi
 echo
 echo "Source configuration"
 echo "--------------------"
+echo "Choose the spec source for this project:"
+echo "  1) local    — specs live only in .sdd/specs/ (no external sync)"
+echo "  2) jira     — sync specs with Jira issues via acli"
+echo "  3) youtrack — sync specs with YouTrack issues via REST API"
+echo
 
-JIRA_ENABLED=$(prompt_yn "Enable Jira as a spec source?" "n")
+SOURCE_CHOICE=""
+while :; do
+  SOURCE_CHOICE=$(prompt "Enter your choice (1/2/3)" "1")
+  case "$SOURCE_CHOICE" in
+    1) SELECTED_SOURCE="local";    break ;;
+    2) SELECTED_SOURCE="jira";     break ;;
+    3) SELECTED_SOURCE="youtrack"; break ;;
+    *) echo "Invalid choice. Please enter 1, 2, or 3." ;;
+  esac
+done
+
+JIRA_ENABLED=false
 JIRA_PROJECT_KEY=""
 JIRA_WORKSPACE=""
-CLAUDE_ATTRIBUTION=$(prompt_yn "Include Claude as a co-author in commits and PR bodies?" "y")
+YOUTRACK_ENABLED=false
+YOUTRACK_BASE_URL=""
+YOUTRACK_TOKEN_ENV="YOUTRACK_TOKEN"
+YOUTRACK_PROJECT_ID=""
 
-if [ "$JIRA_ENABLED" = "true" ]; then
+if [ "$SELECTED_SOURCE" = "jira" ]; then
+  JIRA_ENABLED=true
   if ! command -v acli >/dev/null 2>&1; then
     echo
     echo "Warning: 'acli' (Atlassian CLI) is not on PATH."
@@ -204,12 +224,8 @@ if [ "$JIRA_ENABLED" = "true" ]; then
   JIRA_WORKSPACE=$(prompt "acli workspace" "")
 fi
 
-YOUTRACK_ENABLED=$(prompt_yn "Enable YouTrack as a spec source?" "n")
-YOUTRACK_BASE_URL=""
-YOUTRACK_TOKEN_ENV="YOUTRACK_TOKEN"
-YOUTRACK_PROJECT_ID=""
-
-if [ "$YOUTRACK_ENABLED" = "true" ]; then
+if [ "$SELECTED_SOURCE" = "youtrack" ]; then
+  YOUTRACK_ENABLED=true
   if ! command -v curl >/dev/null 2>&1; then
     echo
     echo "Warning: 'curl' is not on PATH. The YouTrack adapter requires curl."
@@ -228,6 +244,9 @@ if [ "$YOUTRACK_ENABLED" = "true" ]; then
   fi
   YOUTRACK_PROJECT_ID=$(prompt "YouTrack project ID (optional, for future create-on-push)" "")
 fi
+
+echo
+CLAUDE_ATTRIBUTION=$(prompt_yn "Include Claude as a co-author in commits and PR bodies?" "y")
 
 echo
 echo "Version control"
@@ -274,18 +293,16 @@ cat > "$DST_CONFIG" <<EOF
 {
   "claude_attribution": $CLAUDE_ATTRIBUTION,
   "track_specs": $TRACK_SPECS,
+  "source": "$SELECTED_SOURCE",
   "sources": {
     "local": {
-      "enabled": true,
       "path": ".sdd/specs"
     },
     "jira": {
-      "enabled": $JIRA_ENABLED,
       "project_key": "$JIRA_PROJECT_KEY",
       "workspace": "$JIRA_WORKSPACE"
     },
     "youtrack": {
-      "enabled": $YOUTRACK_ENABLED,
       "base_url": "$YOUTRACK_BASE_URL",
       "token_env": "$YOUTRACK_TOKEN_ENV",
       "project_id": "$YOUTRACK_PROJECT_ID"
@@ -314,13 +331,10 @@ cat <<EOF
 Done.
 
 Claude attribution: $CLAUDE_ATTRIBUTION
-Enabled sources:
-  local:     true
-  jira:      $JIRA_ENABLED
-  youtrack:  $YOUTRACK_ENABLED
+Source: $SELECTED_SOURCE
 EOF
 
-if [ "$JIRA_ENABLED" = "true" ]; then
+if [ "$SELECTED_SOURCE" = "jira" ]; then
   cat <<EOF
     project_key: $JIRA_PROJECT_KEY
     workspace:   $JIRA_WORKSPACE
@@ -329,7 +343,7 @@ if [ "$JIRA_ENABLED" = "true" ]; then
 EOF
 fi
 
-if [ "$YOUTRACK_ENABLED" = "true" ]; then
+if [ "$SELECTED_SOURCE" = "youtrack" ]; then
   cat <<EOF
     base_url:  $YOUTRACK_BASE_URL
     token_env: $YOUTRACK_TOKEN_ENV

--- a/sdd/sources.md
+++ b/sdd/sources.md
@@ -2,7 +2,7 @@
 
 Specs can come from different systems. Each source implements the same contract so `/spec-draft`, `/spec-plan`, and `/spec-build` can handle it uniformly via the `spec-source` skill.
 
-Enabled adapters and their config live in `.sdd/config.json` under `sources`.
+The active adapter is set by the top-level `source` field in `.sdd/config.json` (one of `local`, `jira`, `youtrack`). Per-adapter config lives under the `sources` key.
 
 ## Contract
 
@@ -74,5 +74,5 @@ description=$(echo "$response" | python3 -c "import json,sys; d=json.load(sys.st
 ## Adding an adapter
 
 1. Add a section here with the four operations.
-2. Add a key under `sources` in `.sdd/config.json`.
+2. Add a key under `sources` in `.sdd/config.json`. The user selects the adapter during `spec-init` via the top-level `source` field.
 3. No skill or command changes — they read this catalog at runtime.

--- a/templates/spec.md
+++ b/templates/spec.md
@@ -3,8 +3,8 @@ spec_id: <SPEC-ID>
 spec_type: <feature|bugfix|refactor|chore|docs|experiment|hotfix|release|support>
 spec_title: <Title Case Description>
 branch: <spec_type>/<SPEC-ID>-<Title-Case-Words-Joined-By-Dashes>
-source: <local|jira>
-source_ref: <null or external reference, e.g. JIRA key>
+source: <local|jira|youtrack>
+source_ref: <null or external reference, e.g. JIRA key or YouTrack issue ID>
 ---
 
 # Spec: <spec_title>


### PR DESCRIPTION
## Summary

Replace the independent multi-source toggle model (enable Jira? enable YouTrack?) with a single-choice source selection during `spec-init`. The project now uses exactly one source adapter, stored in a top-level `"source"` field in `.sdd/config.json`.

## Changes

- **setup.sh**: Single-choice numbered menu (1=local, 2=jira, 3=youtrack) replaces independent yes/no prompts. Config writes `"source"` field, drops per-adapter `"enabled"` flags.
- **spec-draft.md**: Step 4 reads `source` field directly — no more listing enabled sources or prompting the user to pick.
- **sources.md / spec-source SKILL.md**: Updated config references and adapter registration docs.
- **spec template**: Added `youtrack` to frontmatter source enum.

## Commits

82a38e5 SDD-10: update docs and template for single-source config model
0ce2075 SDD-10: read single source field in spec-draft instead of listing enabled sources
ec3051b SDD-10: replace multi-source toggles with single-choice menu in setup wizard

Closes #10