### PR TITLE
fix: convert markdown to Jira wiki markup on push

### DIFF
--- a/ai/claude/skills/spec-source/SKILL.md
+++ b/ai/claude/skills/spec-source/SKILL.md
@@ -17,7 +17,8 @@ Returns the external description as a markdown body (no frontmatter).
 
 1. `source == "local"` → return empty template body.
 2. Else → follow pull procedure for `source` in `.sdd/sources.md`.
-3. Auth failure → print:
+3. If the returned body is in a non-markdown format (e.g., Jira wiki markup), convert it to markdown before returning. Follow the reverse of the format conversion rules in `.sdd/sources.md`.
+4. Auth failure → print:
    ```
    <source> authentication failed. Run `<source auth command>`, then type "continue" to retry.
    ```
@@ -45,10 +46,12 @@ Sends local body to the external source and refreshes the cache.
 1. `source == "local"` → no-op.
 2. Call `detect_conflict` first. If conflict and user does not `continue` → stop, do not overwrite.
 3. Strip frontmatter (everything between the first and second `---`, inclusive).
-4. Write stripped body to a temp file.
-5. Follow push procedure for `source` in `.sdd/sources.md` using the temp file.
-6. Auth failure → handle same as `pull`.
-7. Success → overwrite `.sdd/specs/.cache/<ref>.<source>.md` with pushed body. Create `.sdd/specs/.cache/` if missing.
+4. Strip the first `# Spec: …` heading line — external systems already use the ticket title/summary; a duplicate heading in the description is redundant.
+5. Strip HTML comments (`<!-- … -->`).
+6. **Convert to the target format.** Specs are authored in markdown, but not all backends accept markdown natively. Follow the format conversion instructions for `source` in `.sdd/sources.md` (e.g., Jira requires wiki markup). Write the converted body to a temp file.
+7. Follow push procedure for `source` in `.sdd/sources.md` using the temp file.
+8. Auth failure → handle same as `pull`.
+9. Success → overwrite `.sdd/specs/.cache/<ref>.<source>.md` with the **original markdown** body (pre-conversion) so that cache comparisons remain in a single format.
 
 ### `detect_conflict(source, ref) -> (has_conflict, diff)`
 
@@ -71,6 +74,9 @@ Checks for external drift since the last known sync.
 ## Guarantees
 
 - **Frontmatter is local-only.** Never push it. Always strip between first and second `---`.
+- **Title heading is local-only.** Strip the first `# Spec: …` line before pushing — external systems already display the ticket title.
+- **Format conversion is required.** Push the body in the format the target system expects (e.g., Jira wiki markup), not raw markdown. See `.sdd/sources.md` for per-adapter conversion rules.
+- **Cache stores markdown.** Cache files always contain the markdown version (pre-conversion) so comparisons stay consistent.
 - **Cache is authoritative** for last-known remote. Only `pull` and successful `push` may overwrite it.
 - **No silent overwrites.** On drift, user must type `continue` before `push` proceeds.
 - **Auth failures recoverable.** Always offer retry via `continue`.

--- a/sdd/sources.md
+++ b/sdd/sources.md
@@ -60,8 +60,8 @@ and wait.
      | `~~strikethrough~~` | `-strikethrough-` |
      | `> blockquote` (consecutive lines) | `{quote}\n…\n{quote}` |
      | `---` (horizontal rule, standalone line) | `----` |
-     | `- [ ] item` | `* (x) item` |
-     | `- [x] item` | `* (/) item` |
+     | `- [ ] item` | `* [] item` |
+     | `- [x] item` | `* [x] item` |
      | `- item` (unordered list) | `* item` |
      | `  - nested` (2-space indent) | `** nested` |
      | `1. item` (ordered list) | `# item` |

--- a/sdd/sources.md
+++ b/sdd/sources.md
@@ -38,9 +38,40 @@ Run `acli auth login`, then type "continue" to retry.
 ```
 and wait.
 
-- `pull(ref)`: `acli jira workitem view --key <ref> --json`, extract `description`. Empty → empty template body.
+- `pull(ref)`: `acli jira workitem view --key <ref> --json`, extract `description`. Empty → empty template body. The returned description may be in Jira wiki markup — convert it to markdown (reverse of the `push` conversion table) before returning the body.
 - `adapt(body)`: match sections to template headers. If mismatched: map into closest sections, leave unmatched as `...`, append unmapped under `## Original Description`. Show proposal, require `continue` before writing.
-- `push(ref, body)`: strip frontmatter, write to temp file, run `acli jira workitem edit --key <ref> --description-file=<tmp>`, then overwrite `.sdd/specs/.cache/<ref>.jira.md` with the pushed body.
+- `push(ref, body)`:
+  1. Strip frontmatter (everything between the first and second `---`, inclusive).
+  2. Strip the first `# Spec: …` heading line — Jira already uses the ticket summary as the title; a duplicate h1 in the description is redundant and renders poorly.
+  3. Strip HTML comments (`<!-- … -->`).
+  4. **Convert markdown → Jira wiki markup** before writing to the temp file. Jira descriptions do not render markdown; they require Jira wiki notation. Apply these transformations in order:
+
+     | Markdown | Jira wiki |
+     |---|---|
+     | `#### heading` | `h4. heading` |
+     | `### heading` | `h3. heading` |
+     | `## heading` | `h2. heading` |
+     | `# heading` | `h1. heading` |
+     | `**bold**` | `*bold*` |
+     | `*italic*` (when not inside a list marker) | `_italic_` |
+     | `` `inline code` `` | `{{inline code}}` |
+     | ` ```lang\n…\n``` ` | `{code:lang}\n…\n{code}` (omit `:lang` when absent) |
+     | `[text](url)` | `[text\|url]` |
+     | `~~strikethrough~~` | `-strikethrough-` |
+     | `> blockquote` (consecutive lines) | `{quote}\n…\n{quote}` |
+     | `---` (horizontal rule, standalone line) | `----` |
+     | `- [ ] item` | `* (x) item` |
+     | `- [x] item` | `* (/) item` |
+     | `- item` (unordered list) | `* item` |
+     | `  - nested` (2-space indent) | `** nested` |
+     | `1. item` (ordered list) | `# item` |
+
+     Process fenced code blocks first (preserve their contents verbatim), then apply the remaining transformations to non-code-block text.
+
+  5. Write the converted body to a temp file.
+  6. Run `acli jira workitem edit --key <ref> --description-file=<tmp>`.
+  7. On success → overwrite `.sdd/specs/.cache/<ref>.jira.md` with the **original markdown** body (not the converted wiki markup) so that `detect_conflict` and future pushes compare markdown against markdown.
+
 - `detect_conflict(ref, cached_body)`: pull current Jira body, diff against `cached_body`. If different, require `continue` before overwrite.
 
 ### `youtrack`
@@ -70,7 +101,7 @@ description=$(echo "$response" | python3 -c "import json,sys; d=json.load(sys.st
 
 - `pull(ref)`: `curl -sS -H "Authorization: Bearer $TOKEN" "$base_url/api/issues/$ref?fields=description"`, extract `description` field. Empty or null → empty template body.
 - `adapt(body)`: same as Jira — match content against template headers; unmapped content → append under `## Original Description`; show proposal; require `continue` before writing.
-- `push(ref, body)`: if `ref` is null/empty, print `YouTrack push skipped: no source_ref set. Create the issue in YouTrack and set source_ref in frontmatter.` and stop. Otherwise: strip frontmatter, write to temp file, run `curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "$base_url/api/issues/$ref" -d "{\"description\": $(jq -Rs . < "$tmpfile")}"`. Verify success: `echo "$response" | jq -e '.["$type"] == "Issue"'` (or python3 equivalent). On success, overwrite `.sdd/specs/.cache/<ref>.youtrack.md` with the pushed body. On failure, print the response body and stop.
+- `push(ref, body)`: if `ref` is null/empty, print `YouTrack push skipped: no source_ref set. Create the issue in YouTrack and set source_ref in frontmatter.` and stop. Otherwise: strip frontmatter, strip the first `# Spec: …` heading line (YouTrack already displays the issue summary), strip HTML comments (`<!-- … -->`), write to temp file, run `curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "$base_url/api/issues/$ref" -d "{\"description\": $(jq -Rs . < "$tmpfile")}"`. Verify success: `echo "$response" | jq -e '.["$type"] == "Issue"'` (or python3 equivalent). On success, overwrite `.sdd/specs/.cache/<ref>.youtrack.md` with the pushed body. On failure, print the response body and stop.
 - `detect_conflict(ref, cached_body)`: pull current remote body, diff against `cached_body`. If different, require `continue` before overwrite (same logic as Jira).
 
 ## Adding an adapter

--- a/sdd/sources.md
+++ b/sdd/sources.md
@@ -60,8 +60,8 @@ and wait.
      | `~~strikethrough~~` | `-strikethrough-` |
      | `> blockquote` (consecutive lines) | `{quote}\n…\n{quote}` |
      | `---` (horizontal rule, standalone line) | `----` |
-     | `- [ ] item` | `* [] item` |
-     | `- [x] item` | `* [x] item` |
+     | `- [ ] item` | `[] item` |
+     | `- [x] item` | `[x] item` |
      | `- item` (unordered list) | `* item` |
      | `  - nested` (2-space indent) | `** nested` |
      | `1. item` (ordered list) | `# item` |


### PR DESCRIPTION
## Summary

Jira descriptions do not render markdown natively — content pushed as raw markdown appeared as plain text, checkboxes showed literal `[ ]` / `[x]`, and the `# Spec:` h1 title was redundant.

## Changes

- **sdd/sources.md**: Expanded Jira `push` procedure with a full markdown-to-wiki-markup conversion table (headings, bold, italic, code blocks, links, checkboxes, lists, blockquotes, strikethrough). Pull now reverse-converts wiki markup to markdown. YouTrack push also strips title heading and HTML comments.
- **spec-source SKILL.md**: Push now strips the `# Spec:` title heading, strips HTML comments, converts to target format, and stores original markdown (not converted) in cache.

## Key fixes
- Markdown → Jira wiki markup conversion on push
- `# Spec: …` title heading stripped (external systems already show ticket title)
- HTML comments stripped before push
- Checkboxes: `- [ ]` → `[]`, `- [x]` → `[x]`
- Cache stores markdown (pre-conversion) for consistent diffs

Closes #7