### PR TITLE
fix: leave commit attribution to Claude Code config

### DIFF
--- a/ai/claude/commands/spec-build.md
+++ b/ai/claude/commands/spec-build.md
@@ -18,9 +18,7 @@ Read `.sdd/specs/<spec_id>.md`. Parse frontmatter (`branch`). Body must contain 
 
 If `branch` is `<none>`, the spec is being built on the current branch — do not refuse to build, do not switch branches.
 
-Read `.sdd/config.json`. Extract `claude_attribution` (top-level boolean field). If the field is absent, non-boolean, or `config.json` is missing, default to `true`. Store as `CLAUDE_ATTRIBUTION` for use in §6 and §8.
-
-Extract `track_specs` (top-level boolean field). If absent, non-boolean, or `config.json` is missing, default to `true`. Store as `TRACK_SPECS` for use in §6.
+Read `.sdd/config.json`. Extract `track_specs` (top-level boolean field). If absent, non-boolean, or `config.json` is missing, default to `true`. Store as `TRACK_SPECS` for use in §6.
 
 ### 2. Find next step
 
@@ -77,10 +75,9 @@ The §4 `AskUserQuestion` invocation is the canonical pause point. Its arguments
 ### 6. Commit and mark done
 
 1. `git add -A`
-2. Commit message. The subject is `<type>: <short description of the change>`; the message may also carry an extended body (the paragraphs after the subject's blank line), which is where commit attribution lives. Do not commit with a bare single-line subject — leave room for the extended body so Claude Code's `Co-Authored-By` trailer has somewhere to go.
+2. Commit message. The subject is `<type>: <short description of the change>`; the message may also carry an extended body (the paragraphs after the subject's blank line). Do not commit with a bare single-line subject — leave room for the extended body so Claude Code's `Co-Authored-By` trailer (governed by Claude Code's own configuration) has somewhere to go.
    - `<type>` is a Conventional-Commits prefix (no scope). Derive it from the spec's frontmatter `spec_type` via this mapping: `feature`→`feat`, `bugfix`→`fix`, `refactor`→`refactor`, `chore`→`chore`, `docs`→`docs`, `experiment`→`experiment`, `hotfix`→`fix`, `release`→`chore`, `support`→`chore`. When the step's actual change clearly belongs to a different category (e.g., a `feature`-typed spec whose step is a pure typo fix), pick the type that matches the change instead.
    - The subject must NOT contain the spec_id, the step number, internal ticket numbers, customer information, credentials, API keys, internal URLs, or external system names. See `## Coding Standards` below.
-   - If `CLAUDE_ATTRIBUTION` is `false`: explicitly suppress attribution. The commit message must not contain any `Co-Authored-By` trailer, model identifier, or `🤖 Generated with Claude Code` line — override Claude Code's default so no trailer is appended.
 3. Update spec: change `- [ ] Step N:` to `- [x] Step N:` for the completed step.
 4. If `TRACK_SPECS` is `true`: `git add .sdd/specs/<spec_id>.md && git commit --amend --no-edit`
    If `TRACK_SPECS` is `false`: skip — the checkbox update lives on disk only.
@@ -99,7 +96,7 @@ Runs once, after all steps are checked, **only if at least one step was committe
 3. If no CLAUDE.md-worthy changes were introduced → skip entirely (do not create a no-op commit).
 4. Otherwise:
    - Edit `CLAUDE.md` to reflect the new facts (new commands, changed invariants, updated tail behaviors, etc.).
-   - Commit subject: `docs: <short description of what was documented>` — same Conventional-Commits format and same attribution rules as §6.2. No spec_id, no step number.
+   - Commit subject: `docs: <short description of what was documented>` — same Conventional-Commits format and message rules as §6.2. No spec_id, no step number.
 5. Then proceed to §8.
 
 ### 8. Completion
@@ -149,7 +146,6 @@ All steps checked:
            - Prepare spec data:
              - `SUMMARY` = spec `## Summary` section body (verbatim).
              - `IMPLEMENTATION` = spec `## Analysis` section body + the step descriptions from `## Implementation Plan` (without checkboxes/status markup). If `## Analysis` is absent, use only the plan steps.
-           - PR bodies must not contain any Claude attribution — no `Co-Authored-By` line, no `🤖 Generated with Claude Code` footer, no model identifier, no "Generated with" mention. This rule is unconditional and does not depend on `CLAUDE_ATTRIBUTION` (that flag governs commit messages only).
            - PR bodies must not include a commit list, changelog, or `## Commits` section. The commit list is already visible in the PR's own "Commits" tab and would be a duplicate. Do not append such a section even when the template lacks one.
            - For each template section, decide by reading the section heading and any placeholder/prompt text:
              - Section asks for a **description, summary, overview, goal, purpose, or context** → replace its body with `SUMMARY`.
@@ -164,7 +160,7 @@ All steps checked:
            ## Summary
            <spec Summary section verbatim>
            ```
-           No commit list, no changelog, no attribution footer is appended.
+           No commit list or changelog is appended.
 
      4. On `gh` success print the PR URL.
      5. On `gh` failure (not installed, not authenticated, etc.): keep the push, print the error verbatim, and print the equivalent manual command the user can run.
@@ -211,4 +207,4 @@ When such information is genuinely needed to explain a change, generalise it: "t
 
 - Subjects use the Conventional-Commits format from §6.2 — no spec_id, no step number, no internal references.
 - Bodies, when present, describe *what* the change does and *why*, in normal prose. They must not list the spec_id, step number, or any of the sensitive-information items above.
-- PR bodies follow §8.3 — no attribution, no commit list.
+- PR bodies follow §8.3 — no commit list.

--- a/ai/claude/commands/spec-draft.md
+++ b/ai/claude/commands/spec-draft.md
@@ -90,11 +90,11 @@ If `TRACK_SPECS` is `true`:
 ```
 git add .sdd/specs/<spec_id>.md
 git commit -m "<type>: refresh spec"
-# subject above; Claude Code appends its Co-Authored-By trailer as the body
-# unless claude_attribution is false (then commit the subject alone)
+# subject above; Claude Code appends its Co-Authored-By trailer (per its own
+# configuration) as the body — leave room for it, don't force a bare subject
 ```
 
-`<type>` is a Conventional-Commits prefix. Default to `docs` (a spec refresh is documentation work); pick a different prefix when the refresh content clearly belongs elsewhere. The subject must not contain the spec_id, the step number, internal ticket numbers, customer information, credentials, or any other sensitive identifier. Attribution follows the same rules as `/spec-build` §6.2 — the message may carry an extended body where Claude Code's `Co-Authored-By` trailer lives, so do not constrain it to a bare single-line subject; only when `claude_attribution` is `false` is the trailer explicitly suppressed.
+`<type>` is a Conventional-Commits prefix. Default to `docs` (a spec refresh is documentation work); pick a different prefix when the refresh content clearly belongs elsewhere. The subject must not contain the spec_id, the step number, internal ticket numbers, customer information, credentials, or any other sensitive identifier. As in `/spec-build` §6.2, the message may carry an extended body where Claude Code's `Co-Authored-By` trailer lives (governed by Claude Code's own configuration), so do not constrain it to a bare single-line subject.
 
 If `TRACK_SPECS` is `false`: skip — the spec update lives on disk only.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -169,9 +169,6 @@ fi
 # Wizard questions.
 # ---------------------------------------------------------------------------
 
-CLAUDE_ATTRIBUTION=$(prompt_yn "Include Claude as a co-author in commits and PR bodies?" "y")
-
-echo
 echo "Version control"
 echo "---------------"
 echo "Spec files under .sdd/specs/ can be committed alongside your code or kept local-only."
@@ -209,18 +206,18 @@ fi
 cp "$SRC_TEMPLATE" "$DST_TEMPLATE_DIR/spec.md"
 echo "  wrote $DST_TEMPLATE_DIR/spec.md"
 
-# Config. We always rewrite `sdd_version`, `claude_attribution`, and
-# `track_specs` from the wizard's answers. We PRESERVE `source` and the
-# `sources.*` blocks from any existing config — re-running `sdd init`
-# should not wipe a user's Jira/YouTrack configuration.
-python3 - "$DST_CONFIG" "$SDD_VERSION" "$CLAUDE_ATTRIBUTION" "$TRACK_SPECS" <<'PY' > "$DST_CONFIG.tmp"
+# Config. We always rewrite `sdd_version` and `track_specs` from the wizard's
+# answers. We PRESERVE `source` and the `sources.*` blocks from any existing
+# config — re-running `sdd init` should not wipe a user's Jira/YouTrack
+# configuration. Commit attribution is governed by Claude Code's own config,
+# not by SDD.
+python3 - "$DST_CONFIG" "$SDD_VERSION" "$TRACK_SPECS" <<'PY' > "$DST_CONFIG.tmp"
 import json, os, sys
 
-path, ver, attr, track = sys.argv[1:5]
+path, ver, track = sys.argv[1:4]
 
 defaults = {
     "sdd_version": ver,
-    "claude_attribution": attr == "true",
     "track_specs": track == "true",
     "source": "local",
     "sources": {
@@ -242,8 +239,10 @@ if os.path.isfile(path):
 
 # Always-rewrite fields (the wizard owns these).
 cfg["sdd_version"] = defaults["sdd_version"]
-cfg["claude_attribution"] = defaults["claude_attribution"]
 cfg["track_specs"] = defaults["track_specs"]
+
+# Drop the retired `claude_attribution` field from older configs.
+cfg.pop("claude_attribution", None)
 
 # Preserve `source` if previously set to a recognised value; otherwise default.
 if cfg.get("source") not in ("local", "jira", "youtrack"):
@@ -299,7 +298,6 @@ cat <<EOF
 Done.
 
 Toolkit version:    $SDD_VERSION
-Claude attribution: $CLAUDE_ATTRIBUTION
 Track specs in git: $TRACK_SPECS
 Source:             $SELECTED_SOURCE
 


### PR DESCRIPTION
## Summary

Commit attribution was silently dropped even when intended: `/spec-build` and `/spec-draft` framed the commit as a subject-only message, leaving no extended body for the `Co-Authored-By` trailer to live in.

This removes the `claude_attribution` config field entirely — commit and PR-body attribution are governed by Claude Code's own configuration, not by SDD. The commands' only obligation is to never commit with a bare single-line `-m` subject, so the trailer has somewhere to go.

- `spec-build.md`: drop the config extraction and the `claude_attribution` commit/PR-body branches; require an extended commit body; keep the unconditional "no commit list in PR bodies" rule.
- `spec-draft.md`: remove `claude_attribution` references from the refresh-commit prose and example.
- `setup.sh`: remove the wizard prompt, config write, and summary line; pop the retired field from older configs on re-init.