### PR TITLE
Move SDD Ignore Globs To Local Git Exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The wizard:
 - creates `.sdd/` with `config.json` (records the toolkit short SHA in `sdd_version`)
 - copies the spec template into `.sdd/specs/template/spec.md`
 - creates `.sdd/specs/.cache/` for publish state
-- always gitignores the SDD-specific globs `.claude/commands/spec-*.md`, `.claude/skills/spec-*/`, and `.sdd/specs/.cache/` — your own commands/skills under `.claude/` are left alone
+- adds the SDD-specific globs `.claude/commands/spec-*.md` and `.sdd/specs/.cache/` to the clone-local git exclude file (`.git/info/exclude`), not the committed `.gitignore` — the toolkit is project-local and leaves your tracked files and your own `.claude/` content alone (re-running migrates any of these globs left in an older `.gitignore`; outside a git repo this step is skipped)
 - asks whether to track `.sdd/` specs in git (default Yes)
 - asks whether to include Claude as a co-author in commits (default Yes)
 
@@ -274,7 +274,7 @@ your-project/
 ## 🔄 Updating / reinitializing
 
 - **Toolkit update** — run `sdd upgrade`, then `sdd init` in each target project. Existing commands and template are overwritten; your specs and the rest of `config.json` are not (only `sdd_version` is rewritten).
-- **Reset a single project** — delete `.claude/commands/spec-*.md`, `.claude/skills/spec-*/`, `.sdd/`, then re-run `sdd init`.
+- **Reset a single project** — delete `.claude/commands/spec-*.md`, `.sdd/`, then re-run `sdd init`.
 - **Move off the toolkit** — `.sdd/specs/` is just Markdown; it keeps working without the commands.
 - **Legacy `.specs/` directory** — if you have spec files from an older install under `.specs/`, the wizard leaves them untouched. Move them to `.sdd/specs/` manually after reinitializing.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -227,7 +227,10 @@ if [ -d "$SRC_SKILLS" ] && ls "$SRC_SKILLS"/spec-* >/dev/null 2>&1; then
   copy_dir_contents "$SRC_SKILLS" "$DST_SKILLS"
 fi
 
-# Spec template.
+# Spec template. The dir is entirely SDD-owned, so clear it first to drop any
+# template files an older toolkit shipped, then re-populate from the current one.
+rm -rf "$DST_TEMPLATE_DIR"
+mkdir -p "$DST_TEMPLATE_DIR"
 cp "$SRC_TEMPLATE" "$DST_TEMPLATE_DIR/spec.md"
 echo "  wrote $DST_TEMPLATE_DIR/spec.md"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -164,7 +164,7 @@ This will:
   • create .sdd/ with config.json (records the toolkit version)
   • copy the spec template into .sdd/specs/template/
   • create .sdd/specs/.cache/ for publish state
-  • always gitignore .claude/commands/spec-*.md, .claude/skills/spec-*/, .sdd/specs/.cache/
+  • add SDD's ignore globs to the local git exclude (.git/info/exclude, not committed): .claude/commands/spec-*.md, .sdd/specs/.cache/
   • ask whether to track .sdd/ specs in git
 
 Existing files will be overwritten.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -305,16 +305,28 @@ if git -C "$TARGET_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   mkdir -p "$(dirname "$EXCLUDE_FILE")"
 fi
 
-# Always-ignore: SDD-specific paths under .claude/ + the publish cache.
-# Scoped globs only — leave the user's own .claude/ content alone.
-ensure_gitignore_line ".claude/commands/spec-*.md"
-ensure_gitignore_line ".claude/skills/spec-*/"
-ensure_gitignore_line ".sdd/specs/.cache/"
+# SDD's ignore globs live in the clone-local exclude file, never the committed
+# .gitignore. Scoped globs only — leave the user's own .claude/ content alone.
+# On each run we also migrate any tool-owned globs (including the retired
+# skills glob) off of a .gitignore left behind by an earlier toolkit version.
+if [ "$IS_GIT_REPO" = "true" ]; then
+  for glob in \
+    ".claude/commands/spec-*.md" \
+    ".claude/skills/spec-*/" \
+    ".sdd/specs/.cache/" \
+    ".sdd/"; do
+    remove_gitignore_line "$glob"
+  done
 
-if [ "$TRACK_SPECS" = "false" ]; then
-  ensure_gitignore_line ".sdd/"
+  ensure_exclude_line ".claude/commands/spec-*.md"
+  ensure_exclude_line ".sdd/specs/.cache/"
+  if [ "$TRACK_SPECS" = "false" ]; then
+    ensure_exclude_line ".sdd/"
+  fi
+  echo "  updated $EXCLUDE_FILE"
+else
+  echo "  not a git repository — skipped writing ignore rules (no .git/info/exclude)"
 fi
-echo "  updated $DST_GITIGNORE"
 
 # ---------------------------------------------------------------------------
 # Summary.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -201,7 +201,13 @@ echo "Installing..."
 
 mkdir -p "$DST_COMMANDS" "$DST_SKILLS" "$DST_SDD" "$DST_TEMPLATE_DIR" "$DST_CACHE_DIR"
 
-# Commands (flat .md files).
+# Commands (flat .md files). Clear stale spec-* commands first so any the
+# toolkit no longer ships don't linger after an upgrade. Scoped glob only —
+# the user's own .claude/commands/ files are untouched.
+for f in "$DST_COMMANDS"/spec-*.md; do
+  [ -e "$f" ] || continue
+  rm -f "$f"
+done
 for f in "$SRC_COMMANDS"/*.md; do
   [ -e "$f" ] || continue
   cp "$f" "$DST_COMMANDS/"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -214,8 +214,15 @@ for f in "$SRC_COMMANDS"/*.md; do
   echo "  wrote $DST_COMMANDS/$(basename "$f")"
 done
 
-# Skills (nested directories). Only copy if any exist; the toolkit may ship without
-# any spec-* skills now that caveman/source have been removed.
+# Skills (nested directories). Clear stale spec-* skill dirs first — this runs
+# even when the toolkit ships no skills, which is exactly when a previously
+# installed spec-* skill must be removed. Scoped glob only.
+for d in "$DST_SKILLS"/spec-*; do
+  [ -e "$d" ] || continue
+  rm -rf "$d"
+done
+# Only copy if any exist; the toolkit may ship without any spec-* skills now
+# that caveman/source have been removed.
 if [ -d "$SRC_SKILLS" ] && ls "$SRC_SKILLS"/spec-* >/dev/null 2>&1; then
   copy_dir_contents "$SRC_SKILLS" "$DST_SKILLS"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -105,19 +105,31 @@ prompt_yn() {
   done
 }
 
-ensure_gitignore_line() {
+ensure_exclude_line() {
   line="$1"
-  if [ ! -f "$DST_GITIGNORE" ]; then
-    printf '%s\n' "$line" > "$DST_GITIGNORE"
+  if [ ! -f "$EXCLUDE_FILE" ]; then
+    printf '%s\n' "$line" > "$EXCLUDE_FILE"
     return
   fi
-  if ! grep -Fxq "$line" "$DST_GITIGNORE"; then
+  if ! grep -Fxq "$line" "$EXCLUDE_FILE"; then
     # Guard: if file is non-empty and last byte is not \n, add one.
     # tail -c 1 | wc -l returns 1 when last byte is \n, 0 for any other byte.
-    if [ -s "$DST_GITIGNORE" ] && [ "$(tail -c 1 "$DST_GITIGNORE" | wc -l)" -eq 0 ]; then
-      printf '\n' >> "$DST_GITIGNORE"
+    if [ -s "$EXCLUDE_FILE" ] && [ "$(tail -c 1 "$EXCLUDE_FILE" | wc -l)" -eq 0 ]; then
+      printf '\n' >> "$EXCLUDE_FILE"
     fi
-    printf '%s\n' "$line" >> "$DST_GITIGNORE"
+    printf '%s\n' "$line" >> "$EXCLUDE_FILE"
+  fi
+}
+
+# Strip a glob SDD owns from the project's committed .gitignore (migration off
+# of .gitignore onto info/exclude). No-op when .gitignore is absent or the line
+# is not present. grep -Fxv keeps every line but exact matches of $line.
+remove_gitignore_line() {
+  line="$1"
+  [ -f "$DST_GITIGNORE" ] || return 0
+  if grep -Fxq "$line" "$DST_GITIGNORE"; then
+    grep -Fxv "$line" "$DST_GITIGNORE" > "$DST_GITIGNORE.tmp" || true
+    mv "$DST_GITIGNORE.tmp" "$DST_GITIGNORE"
   fi
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -277,6 +277,22 @@ except Exception:
     print("local")
 ' "$DST_CONFIG")"
 
+# Resolve the clone-local git exclude file. SDD's ignore globs are tool-local,
+# so they belong in .git/info/exclude (per-clone, uncommitted) rather than the
+# project's committed .gitignore. rev-parse handles worktrees / separate git
+# dirs; a relative result is resolved against the target.
+IS_GIT_REPO=false
+EXCLUDE_FILE=""
+if git -C "$TARGET_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  IS_GIT_REPO=true
+  EXCLUDE_FILE="$(git -C "$TARGET_DIR" rev-parse --git-path info/exclude)"
+  case "$EXCLUDE_FILE" in
+    /*) ;;
+    *)  EXCLUDE_FILE="$TARGET_DIR/$EXCLUDE_FILE" ;;
+  esac
+  mkdir -p "$(dirname "$EXCLUDE_FILE")"
+fi
+
 # Always-ignore: SDD-specific paths under .claude/ + the publish cache.
 # Scoped globs only — leave the user's own .claude/ content alone.
 ensure_gitignore_line ".claude/commands/spec-*.md"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -143,7 +143,7 @@ cat <<EOF
 SDD Toolkit uninstalled.
 
 Project directories (.claude/, .sdd/) were not touched.
-To remove SDD from a project, delete .claude/commands/spec-*.md,
-.claude/skills/spec-*/, and .sdd/ manually.
+To remove SDD from a project, delete .claude/commands/spec-*.md
+and .sdd/ manually, then drop the SDD globs from .git/info/exclude.
 ────────────────────────────────────────────────────
 EOF


### PR DESCRIPTION
## Summary
Stop writing SDD's ignore globs to the target's `.gitignore`; write them to the clone-local `.git/info/exclude` instead, and drop the dead `.claude/skills/spec-*/` glob entirely. On re-run, migrate: remove SDD's own globs (including the legacy skills glob) from `.gitignore` and (re)write the current set to the exclude file. When the target is not a git repository, skip ignore-writing and print a warning. Update setup.sh's banner/summary plus README and CLAUDE.md to match. Additionally, make `sdd init` remove stale SDD-managed files left by older toolkit versions — `.claude/commands/spec-*.md` and `.claude/skills/spec-*/` the current toolkit no longer ships, and any leftover contents of the SDD-owned `.sdd/specs/template/` dir — so an upgrade-then-reinit cleans up dropped commands/skills/template instead of leaving them behind.