### PR TITLE
Gate Update Check To SDD Projects

### DIFF
--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -17,8 +17,8 @@ COOLDOWN_FILE="$HOME/.sdd/.last_update_check"
 COOLDOWN_SECONDS=86400
 
 _check_update() {
-  # Only act inside a project that uses the toolkit; stay silent elsewhere.
-  [ -d "$PWD/.sdd" ] || return 0
+  # Only act inside a project initialised by the toolkit; stay silent elsewhere.
+  [ -f "$PWD/.sdd/config.json" ] || return 0
 
   # Cooldown: skip if checked within 24 hours.
   if [ -f "$COOLDOWN_FILE" ]; then

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -17,6 +17,9 @@ COOLDOWN_FILE="$HOME/.sdd/.last_update_check"
 COOLDOWN_SECONDS=86400
 
 _check_update() {
+  # Only act inside a project that uses the toolkit; stay silent elsewhere.
+  [ -d "$PWD/.sdd" ] || return 0
+
   # Cooldown: skip if checked within 24 hours.
   if [ -f "$COOLDOWN_FILE" ]; then
     last=$(cat "$COOLDOWN_FILE" 2>/dev/null) || return 0


### PR DESCRIPTION
## Summary
Gate `check-update.sh`'s toolkit-update remote fetch and its blocking `Install now? [Y/n]` prompt on the current working directory being an SDD project. When the terminal is opened in a directory that does not use the toolkit, the script must stay completely silent and perform no network call. The per-project reinit advice stays as-is (already PWD-gated).